### PR TITLE
remove empty suboptions

### DIFF
--- a/plugins/modules/nim_upgradeios.py
+++ b/plugins/modules/nim_upgradeios.py
@@ -101,18 +101,15 @@ options:
     description:
     - Specifies additional parameters.
     type: dict
-    suboptions:
   vios_status:
     description:
     - Specifies the result of a previous operation.
     type: dict
-    suboptions:
   nim_node:
     description:
     - Allows to pass along NIM node info from a task to another so that it
       discovers NIM info only one time for all tasks.
     type: dict
-    suboptions:
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/nim_vios_alt_disk.py
+++ b/plugins/modules/nim_vios_alt_disk.py
@@ -55,13 +55,11 @@ options:
     description:
     - Specifies the result of a previous operation.
     type: dict
-    suboptions:
   nim_node:
     description:
     - Allows to pass along NIM node info from a task to another so that it
       discovers NIM info only one time for all tasks.
     type: dict
-    suboptions:
   disk_size_policy:
     description:
     - Specifies how to choose the alternate disk if not specified.

--- a/plugins/modules/nim_vios_hc.py
+++ b/plugins/modules/nim_vios_hc.py
@@ -43,7 +43,6 @@ options:
     description:
     - Specifies additional parameters.
     type: dict
-    suboptions:
 notes:
   - Requires vioshc.py available at U(https://github.com/aixoss/vios-health-checker).
 '''

--- a/plugins/modules/nim_viosupgrade.py
+++ b/plugins/modules/nim_viosupgrade.py
@@ -37,12 +37,10 @@ options:
     description:
     - Specifies additional parameters.
     type: dict
-    suboptions:
   vios_status:
     description:
     - Specifies the result of a previous operation.
     type: dict
-    suboptions:
   targets:
     description:
     - NIM targets.


### PR DESCRIPTION
empty suboptions fields as it fails ansible-doc-extractor
The issue are:
- nim_updateios.py line 82 and 88
- nim_upgradeios.py line 104, 109 and 115
- nim_vios_alt_disk.py line 59 and 65
- nim_vios_hc.py line 46
- nim_vios_upgrade.py line 40 and 45