### PR TITLE
flrtvc: improve lslpp.txt version parsing

### DIFF
--- a/plugins/modules/flrtvc.py
+++ b/plugins/modules/flrtvc.py
@@ -696,7 +696,19 @@ def parse_lpps_info():
                 continue
             lpps_lvl[mylist[1]] = {'str': mylist[2]}
             mylist[2] = re.sub(r'-', '.', mylist[2])
-            lpps_lvl[mylist[1]]['int'] = list(map(int, mylist[2].split('.')))
+
+            lpps_lvl[mylist[1]]['int'] = []
+            for version in mylist[2].split('.'):
+                match_key = re.match(r"^(\d+)(\D+\S*)?$", version)
+                if match_key:
+                    lpps_lvl[mylist[1]]['int'].append(int(match_key.group(1)))
+                    if match_key.group(2):
+                        module.log('file {0}: got version "{1}", ignoring "{2}"'.format(lslpp_file, mylist[2], match_key.group(2)))
+                else:
+                    msg = 'file {0} is malformed'.format(lslpp_file)
+                    module.log('{0}: got version: "{1}"'.format(msg, version))
+                    results['meta']['messages'].append(msg)
+                    continue
 
     return lpps_lvl
 

--- a/plugins/modules/nim_flrtvc.py
+++ b/plugins/modules/nim_flrtvc.py
@@ -753,7 +753,19 @@ def parse_lpps_info(module, output, machine):
                 continue
             lpps_lvl[mylist[1]] = {'str': mylist[2]}
             mylist[2] = re.sub(r'-', '.', mylist[2])
-            lpps_lvl[mylist[1]]['int'] = list(map(int, mylist[2].split('.')))
+
+            lpps_lvl[mylist[1]]['int'] = []
+            for version in mylist[2].split('.'):
+                match_key = re.match(r"^(\d+)(\D+\S*)?$", version)
+                if match_key:
+                    lpps_lvl[mylist[1]]['int'].append(int(match_key.group(1)))
+                    if match_key.group(2):
+                        module.log('file {0}: got version "{1}", ignoring "{2}"'.format(lslpp_file, mylist[2], match_key.group(2)))
+                else:
+                    msg = 'file {0} is malformed'.format(lslpp_file)
+                    module.log('{0}: got version: "{1}"'.format(msg, version))
+                    results['meta']['messages'].append(msg)
+                    continue
 
     return lpps_lvl
 


### PR DESCRIPTION
Ignore any string into the version numbers such as: ignoring "waixX11" in "2.3.2-4waixX11".