### PR TITLE
Improve nim_vios_alt_disk, nim_backup, nim_updateios, user and group

### DIFF
--- a/plugins/modules/nim_backup.py
+++ b/plugins/modules/nim_backup.py
@@ -715,9 +715,13 @@ def nim_mksysb_restore(module, target, params):
         cmd += ['-a', 'mksysb={0}'.format(name)]
         cmd += ['-a', 'spot={0}'.format(spot_name)]
 
-    if not params['accept_licenses']:
+    if params['accept_licenses']:
+        cmd += ['-a', 'accept_licenses=yes']
+    else:
         cmd += ['-a', 'accept_licenses=no']
-    if not params['boot_target']:
+    if params['boot_target']:
+        cmd += ['-a', 'boot_client=yes']
+    else:
         cmd += ['-a', 'boot_client=no']
     cmd += [target]
 
@@ -872,13 +876,13 @@ def nim_iosbackup_restore(module, target, params):
     return True
 
 
-def nim_list_backup(module, target, type, params):
+def nim_list_backup(module, target, objtype, params):
     """
     Perform a viosbr NIM operation to resote a VIOS backup
 
     arguments:
         module  (dict): the module variable
-        type     (str): the type of the object to list
+        objtype  (str): the type of the object to list
         target  (list): the NIM Clients to filter backup list
         params  (dict): the NIM command parameters
     return:
@@ -900,7 +904,7 @@ def nim_list_backup(module, target, type, params):
         backup_info.update(build_dict(module, stdout))
         return backup_info
 
-    backup_info.update(get_nim_type_info(module, type))
+    backup_info.update(get_nim_type_info(module, objtype))
 
     # Filter results
     for backup in backup_info.copy():
@@ -1073,7 +1077,8 @@ def main():
         for target in targets:
             if target in results['nim_node']['standalone']:
                 if objtype != 'mksysb':
-                    results['meta'][target]['messages'].append('Cannot {0} {1} on a standalone machine.'.format(action, type))
+                    results['meta'][target]['messages'].append('Operation {0} {1} not supported on a standalone machine. You may want to select mksysb.'
+                                                               .format(action, objtype))
                     results['status'][target] = 'FAILURE'
                     continue
 
@@ -1081,7 +1086,8 @@ def main():
 
             elif target in results['nim_node']['vios']:
                 if objtype == 'mksysb':
-                    results['meta'][target]['messages'].append('Cannot {0} {1} on a VIOS.'.format(action, type))
+                    results['meta'][target]['messages'].append('Operation {0} {1} not supported on a VIOS. You may want to select ios_mksysb.'
+                                                               .format(action, objtype))
                     results['status'][target] = 'FAILURE'
                     continue
 
@@ -1096,11 +1102,13 @@ def main():
         for target in targets:
 
             if target in results['nim_node']['standalone'] and objtype != 'mksysb':
-                results['meta'][target]['messages'].append('Cannot {0} {1} on a standalone machine.'.format(action, type))
+                results['meta'][target]['messages'].append('Operation {0} {1} not supported on a standalone machine. You may want to select mksysb.'
+                                                           .format(action, objtype))
                 results['status'][target] = 'FAILURE'
                 continue
             if target in results['nim_node']['vios'] and objtype == 'mksysb':
-                results['meta'][target]['messages'].append('Cannot {0} {1} on a VIOS.'.format(action, type))
+                results['meta'][target]['messages'].append('Operation {0} {1} not supported on a VIOS. You may want to select ios_mksysb.'
+                                                           .format(action, objtype))
                 results['status'][target] = 'FAILURE'
                 continue
 

--- a/plugins/modules/nim_backup.py
+++ b/plugins/modules/nim_backup.py
@@ -1152,9 +1152,10 @@ def main():
     target_errored = [key for key, val in results['status'].items() if 'FAILURE' in val]
     if len(target_errored):
         results['msg'] = "NIM backup {0} operation failed for {1}. See status and meta for details.".format(action, target_errored)
+        module.fail_json(**results)
     else:
         results['msg'] = 'NIM backup {0} operation successfull. See status and meta for details.'.format(action)
-    module.exit_json(**results)
+        module.exit_json(**results)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/nim_backup.py
+++ b/plugins/modules/nim_backup.py
@@ -212,7 +212,7 @@ targets:
     elements: str
     sample: [nimclient01, nimclient02, ...]
 status:
-    description: Satus of the operation for each C(target). It can be empty, SUCCESS or FAILURE.
+    description: Status of the operation for each C(target). It can be empty, SUCCESS or FAILURE.
     returned: always
     type: dict
     contains:
@@ -1127,11 +1127,11 @@ def main():
         wait_all()
 
     # Exit
-    for target in targets:
-        if 'FAILURE' in results['status'][target]:
-            results['msg'] = 'At least one {0} operation failed. See meta data for details on targets'.format(action)
-            module.fail_json(**results)
-    results['msg'] = '{0} operation successfull.'.format(action)
+    target_errored = [key for key, val in results['status'].items() if 'FAILURE' in val]
+    if len(target_errored):
+        results['msg'] = "NIM backup {0} operation failed for {1}. See status and meta for details.".format(action, target_errored)
+    else:
+        results['msg'] = 'NIM backup {0} operation successfull. See status and meta for details.'.format(action)
     module.exit_json(**results)
 
 

--- a/plugins/modules/nim_backup.py
+++ b/plugins/modules/nim_backup.py
@@ -124,6 +124,13 @@ options:
     - Can be used on a standalone client if I(action=restore).
     type: path
     default: /export/nim/spot
+  bosinst_data:
+    description:
+    - Specifies the bosinst_data resource to restore the backup on a standalone client.
+    - This allows running "non-prompted" installations, and so more automated restorations.
+    - If not specified you will be presented with a series of choices on the console.
+    - Can be used if I(action=restore).
+    type: str
   oslevel:
     description:
     - Specifies the oslevel to filter results.
@@ -715,6 +722,11 @@ def nim_mksysb_restore(module, target, params):
         cmd += ['-a', 'mksysb={0}'.format(name)]
         cmd += ['-a', 'spot={0}'.format(spot_name)]
 
+    if params['bosinst_data']:
+        cmd += ['-a', 'bosinst_data={0}'.format(params['bosinst_data'])]
+    else:
+        results['meta'][target]['messages'].append('Warning: No bosinst_data specified, you will be prompted for additional settings on the console.')
+
     if params['accept_licenses']:
         cmd += ['-a', 'accept_licenses=yes']
     else:
@@ -986,6 +998,7 @@ def main():
             name_prefix=dict(type='str'),
             name_postfix=dict(type='str'),
             group=dict(type='str'),
+            bosinst_data=dict(type='str'),
             spot_name=dict(type='str'),
             spot_prefix=dict(type='str'),
             spot_postfix=dict(type='str', default='_spot'),
@@ -1114,6 +1127,7 @@ def main():
 
             if 'mksysb' in objtype:
                 params['group'] = module.params['group']
+                params['bosinst_data'] = module.params['bosinst_data']
                 params['spot_name'] = module.params['spot_name']
                 if not params['spot_name']:
                     params['spot_prefix'] = module.params['spot_prefix']

--- a/plugins/modules/nim_updateios.py
+++ b/plugins/modules/nim_updateios.py
@@ -32,11 +32,10 @@ options:
     - Specifies the operation telling updateios what operation to perform on the VIOS.
     - C(install) installs new and supported filesets.
     - C(commit) commits all uncommitted updates.
-    - C(reject) rejects all uncommitted updates.
     - C(cleanup) removes all incomplete pieces of the previous installation.
     - C(remove) removes the listed filesets from the system in C(filesets) or C(installp_bundle).
     type: str
-    choices: [ install, commit, reject, cleanup, remove ]
+    choices: [ install, commit, cleanup, remove ]
     required: true
   targets:
     description:
@@ -816,7 +815,7 @@ def nim_updateios(module, targets_list, vios_status, time_limit):
             results['status'][vios_key] = "SKIPPED-TIMEOUT"
             return
 
-        if module.params('action') in ['install', 'reject', 'cleanup'] and module.params['manage_ssp']:
+        if module.params('action') in ['install', 'cleanup'] and module.params['manage_ssp']:
             # check if SSP is defined for this VIOSes tuple.
             if not check_vios_ssp_status(module, target_tuple):
                 msg = "{0} VIOSes skipped (bad SSP status)".format(vios_key)
@@ -849,7 +848,7 @@ def nim_updateios(module, targets_list, vios_status, time_limit):
 
             # if needed stop the SSP for the VIOS
             restart_needed = False
-            if tuple_len == 2 and module.params('action') in ['install', 'reject', 'cleanup'] and module.params['manage_ssp']:
+            if tuple_len == 2 and module.params('action') in ['install', 'cleanup'] and module.params['manage_ssp']:
                 if not ssp_stop_start(module, target_tuple, vios_key, vios, 'stop'):
                     results['status'][vios_key] = err_label
                     break  # cannot continue
@@ -886,7 +885,6 @@ def nim_updateios(module, targets_list, vios_status, time_limit):
                 break
 
 
-###################################################################################
 
 def main():
     global module
@@ -894,8 +892,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            action=dict(choices=['install', 'commit', 'reject', 'cleanup', 'remove'],
-                        required=True, type='str'),
+            action=dict(choices=['install', 'commit', 'cleanup', 'remove'], required=True, type='str'),
             targets=dict(required=True, type='list', elements='str'),
             filesets=dict(type='str'),
             installp_bundle=dict(type='str'),

--- a/plugins/modules/nim_updateios.py
+++ b/plugins/modules/nim_updateios.py
@@ -186,7 +186,7 @@ nim_node:
                     "netboot_kernel": "64",
                     "platform": "chrp",
                     "prev_state": "customization is being performed",
-                    "type": "standalone"
+                    "type": "standalone",
                     "hostname": "nimclient01.aus.stglabs.ibm.com",
                 }
             },
@@ -205,8 +205,8 @@ nim_node:
                     "platform": "chrp",
                     "prev_state": "alt_disk_install operation is being performed",
                     "hostname": "vios1.aus.stglabs.ibm.com",
-                    "ssp_cluster_name": "porthos_cl1"
-                    "ssp_status": "DOWN"
+                    "ssp_cluster_name": "porthos_cl1",
+                    "ssp_status": "DOWN",
                 }
             }
         }
@@ -460,23 +460,23 @@ def check_vios_targets(module, targets):
                 continue
 
             # Get VIOS interface info in case we need to connect using c_rsh
-            if 'if1' not in results['nim_node']['vios'][vios]:
+            if 'if1' not in results['nim_node']['vios'][elem]:
                 msg = "VIOS {0} has no interface set, check its configuration in NIM, tuple {1} will be ignored".format(elem, tuple_elts)
                 module.log(msg)
                 results['meta']['messages'].append(msg)
                 error = True
                 continue
-            fields = results['nim_node']['vios'][vios]['if1'].split(' ')
+            fields = results['nim_node']['vios'][elem]['if1'].split(' ')
             if len(fields) < 2:
                 msg = "VIOS {0} has no hostname set, check its configuration in NIM, tuple {1} will be ignored".format(elem, tuple_elts)
                 module.log(msg)
                 results['meta']['messages'].append(msg)
                 error = True
                 continue
-            results['nim_node']['vios'][vios]['hostname'] = fields[1]
+            results['nim_node']['vios'][elem]['hostname'] = fields[1]
 
             # check vios connectivity
-            cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', results['nim_node']['vios'][vios]['hostname'],
+            cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', results['nim_node']['vios'][elem]['hostname'],
                    '"/usr/bin/ls /dev/null; echo rc=$?"']
             rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
             if rc != 0:
@@ -883,7 +883,6 @@ def nim_updateios(module, targets_list, vios_status, time_limit):
 
             if skip_next_target:
                 break
-
 
 
 def main():

--- a/plugins/modules/nim_updateios.py
+++ b/plugins/modules/nim_updateios.py
@@ -20,8 +20,8 @@ short_description: Use NIM to update a single or a pair of Virtual I/O Servers t
 description:
 - Uses the NIM to perform updates and customization to Virtual I/O Server (VIOS) targets tuple.
 - Checks status of previous operation if provided before running its operations.
-- VIOSes of a tuple must be on the same SSP and its state must be UP.
-- When updating VIOSes in pair, it checks the SSP state, stop it before installing the VIOS, and restart it after installation.
+- VIOSes of a tuple must be on the same SSP cluster and its state must be OK.
+- When updating VIOSes pair, it checks the SSP cluster state, stop it before installing the VIOS, and restart it after installation.
 version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
@@ -64,6 +64,11 @@ options:
     - Specifies whether the software licenses should be automatically accepted during the installation.
     type: bool
     default: True
+  manage_ssp:
+    description:
+    - Specifies whether the SSP cluster should be check and stop before updating the vios and restarted after.
+    type: bool
+    default: False
   preview:
     description: Specifies a preview operation. No action is actually performed.
     type: bool
@@ -88,12 +93,22 @@ options:
 '''
 
 EXAMPLES = r'''
-- name: Update a pair of VIOSes
+- name: Preview updateios on a pair of VIOSes
   nim_updateios:
-    targets: (nimvios01, nimvios02)
+    targets: 'nimvios01, nimvios02'
     action: install
     lpp_source: 723lpp_res
     preview: yes
+- name: Update VIOSes as a pair and a VIOS alone discarding SSP
+  nim_updateios:
+    targets:
+    - nimvios01,nimvios02
+    - nimvios03
+    action: install
+    lpp_source: 723lpp_res
+    time_limit: '07/21/2020 17:02'
+    manage_ssp: no
+    preview: no
 '''
 
 RETURN = r'''
@@ -128,7 +143,7 @@ status:
             - I(SKIPPED-NO-PREV-STATUS) when no I(vios_status) value is found for the tuple.
             - Previous I(vios_status) when the tuple status does not contains SUCCESS.
             - I(SKIPPED-TIMEOUT) when the I(time_limit) is reached before updating the 1st VIOS of the tuple.
-            - I(FAILURE-SSP) when SSP checks or operation failed.
+            - I(FAILURE-SSP) when SSP cluster checks or operation failed.
             - I(FAILURE-UPDT1) when update of first VIOS of the tuple failed.
             - I(FAILURE-UPDT2) when update of second VIOS of the tuple failed.
             returned: when tuple are actually a NIM client and reachable with c_rsh.
@@ -173,6 +188,7 @@ nim_node:
                     "platform": "chrp",
                     "prev_state": "customization is being performed",
                     "type": "standalone"
+                    "hostname": "nimclient01.aus.stglabs.ibm.com",
                 }
             },
             "vios": {
@@ -189,6 +205,9 @@ nim_node:
                     "netboot_kernel": "64",
                     "platform": "chrp",
                     "prev_state": "alt_disk_install operation is being performed",
+                    "hostname": "vios1.aus.stglabs.ibm.com",
+                    "ssp_cluster_name": "porthos_cl1"
+                    "ssp_status": "DOWN"
                 }
             }
         }
@@ -233,7 +252,6 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 
-# TODO improvement: NIM client name can differs from the cluster node name
 module = None
 results = None
 
@@ -442,8 +460,24 @@ def check_vios_targets(module, targets):
                 error = True
                 continue
 
+            # Get VIOS interface info in case we need to connect using c_rsh
+            if 'if1' not in results['nim_node']['vios'][vios]:
+                msg = "VIOS {0} has no interface set, check its configuration in NIM, tuple {1} will be ignored".format(elem, tuple_elts)
+                module.log(msg)
+                results['meta']['messages'].append(msg)
+                error = True
+                continue
+            fields = results['nim_node']['vios'][vios]['if1'].split(' ')
+            if len(fields) < 2:
+                msg = "VIOS {0} has no hostname set, check its configuration in NIM, tuple {1} will be ignored".format(elem, tuple_elts)
+                module.log(msg)
+                results['meta']['messages'].append(msg)
+                error = True
+                continue
+            results['nim_node']['vios'][vios]['hostname'] = fields[1]
+
             # check vios connectivity
-            cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', elem,
+            cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', results['nim_node']['vios'][vios]['hostname'],
                    '"/usr/bin/ls /dev/null; echo rc=$?"']
             rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
             if rc != 0:
@@ -498,13 +532,12 @@ def check_vios_ssp_status(module, target_tuple):
     """
     global results
 
-    ssp_name = ''
     vios_key = tuple_str(target_tuple)
     tuple_len = len(target_tuple)
 
     for vios in target_tuple:
-        if 'ssp_name' in results['nim_node']['vios'][vios]:
-            del(results['nim_node']['vios'][vios]['ssp_name'])
+        if 'ssp_cluster_name' in results['nim_node']['vios'][vios]:
+            del(results['nim_node']['vios'][vios]['ssp_cluster_name'])
         results['nim_node']['vios'][vios]['ssp_status'] = 'none'
 
     # get the SSP status
@@ -512,9 +545,9 @@ def check_vios_ssp_status(module, target_tuple):
     for vios in target_tuple:
         # Get the cluster name and status
         cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh',
-               results['nim_node']['vios'][vios]['vios_ip'],
+               results['nim_node']['vios'][vios]['hostname'],
                '"LC_ALL=C /usr/ios/cli/ioscli cluster -list &&'
-               ' /usr/ios/cli/ioscli cluster -status -fmt : ; echo rc=$?"']
+               ' /usr/ios/cli/ioscli cluster -status -fmt : -verbose; echo rc=$?"']
 
         rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
         if rc != 0:
@@ -542,55 +575,78 @@ def check_vios_ssp_status(module, target_tuple):
             return False
         else:
             # stdout is like:
-            # gdr_ssp3
-            # gdr_ssp3:OK:castor_gdr_vios3:8284-22A0221FD4BV:17:OK:OK
-            # gdr_ssp3:OK:castor_gdr_vios2:8284-22A0221FD4BV:16:OK:OK
-            lines = stdout.rstrip().splitlines()
-            del(lines[0])
+            # CLUSTER_NAME:    porthos_cl1
+            # CLUSTER_ID:      adf01bd81de611ea8012be6aa4a49d02
+            #
+            # porthos_cl1:OK:porthos-vios1:8286-42A02103341V:2:OK:OK
+            # porthos_cl1:OK:porthos-vios2:8286-42A02103341V:3:OK:OK
+            #
+            # with the following:
+            # Cluster Name:Cluster State:Node Name:Node MTM:Node Partition Num:Node State:Pool State
+            # Let's remove the first 3 lines
+            lines = stdout.rstrip().splitlines()[3:]
 
-        # check that the VIOSes belong to the same cluster and have the same satus or there is no SSP
         for line in lines:
-            line = line.rstrip()
-            if not line or len(line) <= 3:
+            line = line.strip()
+            if not line:
                 continue
             fields = line.split(':')
-            ssp_name = fields[0]
-            vios_name = fields[2]
-            ssp_status = fields[1]  # TODO: VRO check the position of the SSP status in the line
-
-            if vios_name not in target_tuple:
+            if len(line) != 7:
+                msg = 'Expecting 21 fields for SSP status, got {0}.'.format(len(line))
+                module.log('[WARNING] ' + msg)
+                results['meta']['messages'].append(msg)
                 continue
+            ssp_cluster_name = fields[0]
+            ssp_node_name = fields[2]
+            ssp_status = fields[6]
 
-            if 'ssp_name' not in results['nim_node']['vios'][vios_name]:
-                results['nim_node']['vios'][vios_name]['ssp_name'] = ssp_name
-                results['nim_node']['vios'][vios_name]['ssp_status'] = ssp_status
-            elif ssp_name != results['nim_node']['vios'][vios_name]['ssp_name']:
+            # check node is in tuple
+            # TODO Improvement: ssp_cluster_name is a short hostname. But hostname here after is from 'if1' definition and can
+            # be an IP address. Moreover tuple is NIM client name can differ from hostname. We could get the actual hostname.
+            if ssp_node_name not in target_tuple:
+                if ssp_node_name in results['nim_node']['vios'][target_tuple[0]]['hostname']:
+                    ssp_node_name = target_tuple[0]
+                elif tuple_len > 1 and ssp_node_name in results['nim_node']['vios'][target_tuple[1]]['hostname']:
+                    ssp_node_name = target_tuple[1]
+                else:
+                    msg = 'Node {0} not found in target_tuple: {1}'.format(ssp_node_name, target_tuple)
+                    module.log(msg)
+                    results['meta'][vios_key]['messages'].append(msg)
+                    continue
+
+            # save the ssp status in results
+            if 'ssp_cluster_name' not in results['nim_node']['vios'][ssp_node_name]:
+                results['nim_node']['vios'][ssp_node_name]['ssp_cluster_name'] = ssp_cluster_name
+                results['nim_node']['vios'][ssp_node_name]['ssp_status'] = ssp_status
+            elif ssp_cluster_name != results['nim_node']['vios'][ssp_node_name]['ssp_cluster_name']:
                 msg = 'VIOS {0} apprears to belong to a different SSP, existing: {1}, got: {2}.'\
-                      .format(vios_name, results['nim_node']['vios'][vios_name]['ssp_name'], ssp_name)
+                      .format(ssp_node_name, results['nim_node']['vios'][ssp_node_name]['ssp_cluster_name'], ssp_cluster_name)
                 module.log(msg)
                 results['meta'][vios_key]['messages'].append(msg)
                 return False
-            elif 'none' != results['nim_node']['vios'][vios_name]['ssp_status']:
+            elif 'none' != results['nim_node']['vios'][ssp_node_name]['ssp_status'] and ssp_status != results['nim_node']['vios'][ssp_node_name]['ssp_status']:
                 msg = 'SSP state on {0} for node {1} is {2}, it differs from existing state: {3}.'\
-                      .format(vios, vios_name, ssp_status, results['nim_node']['vios'][vios_name]['ssp_status'])
+                      .format(vios, ssp_node_name, ssp_status, results['nim_node']['vios'][ssp_node_name]['ssp_status'])
                 module.log(msg)
                 results['meta'][vios_key]['messages'].append(msg)
                 return False
             else:
-                results['nim_node']['vios'][vios_name]['ssp_status'] = ssp_status
+                results['nim_node']['vios'][ssp_node_name]['ssp_status'] = ssp_status
 
             # single VIOS case
             if tuple_len == 1:
-                if results['nim_node']['vios'][vios_name]['ssp_status'] == 'OK':
-                    msg = 'SSP is active for the single VIOS: {0}.'.format(vios_name)
+                if results['nim_node']['vios'][ssp_node_name]['ssp_status'] == 'OK':
+                    msg = 'SSP is active for the single VIOS: {0}.'.format(ssp_node_name)
                     module.log(msg)
                     results['meta'][vios_key]['messages'].append(msg)
                     return False
                 return True
 
-    # Check VIOSes SSP is the same and status is OK
-    if results['nim_node']['vios'][target_tuple[0]]['ssp_name'] != results['nim_node']['vios'][target_tuple[1]]['ssp_name']:
-        msg = 'Both VIOSes must belong to the same SSP'
+    # Check the VIOSes belong to the same cluster and have the same satus OK or there is no SSP
+    if results['nim_node']['vios'][target_tuple[0]]['ssp_cluster_name'] != results['nim_node']['vios'][target_tuple[1]]['ssp_cluster_name']:
+        msg = 'Both VIOSes must belong to the same SSP, got: {0}:{1} and {2}:{3}'\
+              .format(target_tuple[0], results['nim_node']['vios'][target_tuple[0]]['ssp_cluster_name'],
+                      target_tuple[1], results['nim_node']['vios'][target_tuple[1]]['ssp_cluster_name'])
         module.log(msg)
         results['meta'][vios_key]['messages'].append(msg)
         return False
@@ -621,7 +677,7 @@ def ssp_stop_start(module, target_tuple, vios_key, vios, action):
     """
     global results
 
-    # if action is start SSP, find the first node running SSP
+    # if action is start, find the first node running SSP
     node = vios
     if action == 'start':
         for cur_node in target_tuple:
@@ -630,14 +686,14 @@ def ssp_stop_start(module, target_tuple, vios_key, vios, action):
                 break
 
     cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh',
-           results['nim_node']['vios'][node]['vios_ip'],
+           results['nim_node']['vios'][node]['hostname'],
            '"/usr/sbin/clctrl -{0} -n {1} -m {2}; echo rc=$?"'
-           .format(action, results['nim_node']['vios'][vios]['ssp_name'], vios)]
+           .format(action, results['nim_node']['vios'][vios]['ssp_cluster_name'], vios)]
 
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
         msg = 'Cannot {0} SSP on {1} with c_rsh: \'{2}\', rc:{3}, stderr:{4}'\
-              .format(action, results['nim_node']['vios'][node]['vios_ip'], ' '.join(cmd), rc, stderr)
+              .format(action, results['nim_node']['vios'][node]['hostname'], ' '.join(cmd), rc, stderr)
         module.log('[WARNING] ' + msg)
         results['meta'][vios_key]['messages'].append(msg)
         return False
@@ -645,7 +701,7 @@ def ssp_stop_start(module, target_tuple, vios_key, vios, action):
         rc, stdout = compute_c_rsh_rc(node, rc, stdout)
         if rc != 0:
             msg = 'Failed to {0} SSP cluster {1} on {2}: {3}'\
-                  .format(action, results['nim_node']['vios'][vios]['ssp_name'], vios, stdout)
+                  .format(action, results['nim_node']['vios'][vios]['ssp_cluster_name'], vios, stdout)
             results['meta'][vios_key]['messages'].append(msg)
             module.log(msg)
             return False
@@ -657,7 +713,7 @@ def ssp_stop_start(module, target_tuple, vios_key, vios, action):
         results['nim_node']['vios'][vios]['ssp_status'] = 'OK'
 
     msg = '{0} SSP cluster {1} on {2} succeeded'\
-          .format(action, results['nim_node']['vios'][vios]['ssp_name'], vios)
+          .format(action, results['nim_node']['vios'][vios]['ssp_cluster_name'], vios)
     module.log(msg)
     results['meta'][vios_key]['messages'].append(msg)
     return True
@@ -680,24 +736,22 @@ def get_updateios_cmd(module):
     if module.params['action'] == 'remove':
         if module.params['filesets']:
             cmd += ['-a', 'filesets={0}'.format(module.params['filesets'])]
-        elif module.params['installp_bundle']:
+        if module.params['installp_bundle']:
             cmd += ['-a', 'installp_bundle={0}'.format(module.params['installp_bundle'])]
-    # TODO: check if updateios support filesets list for commit operation
-    # if module.params['action'] == 'commit':
-    #     if module.params['filesets']:
-    #         cmd += ['-a', 'filesets={0}'.format(module.params['filesets'])]
-    #     else:
-    #         cmd += ['-a', 'filesets=all']
 
     if module.params['lpp_source']:
         if check_lpp_source(module, module.params['lpp_source']):
             cmd += ['-a', 'lpp_source={0}'.format(module.params['lpp_source'])]
 
     if module.params['accept_licenses']:
-        cmd += ['-a', 'accept_licenses=yes']    # default in NIM is no
+        cmd += ['-a', 'accept_licenses=yes']
+    else:
+        cmd += ['-a', 'accept_licenses=no']    # default in NIM
 
-    if not module.params['preview']:
-        cmd += ['-a', 'preview=no']     # default in NIM is yes
+    if module.params['preview']:
+        cmd += ['-a', 'preview=yes']     # default in NIM
+    else:
+        cmd += ['-a', 'preview=no']
 
     return cmd
 
@@ -705,9 +759,21 @@ def get_updateios_cmd(module):
 def nim_updateios(module, targets_list, vios_status, time_limit):
     """
     Execute the updateios command
+    For each VIOS tuple,
+    - retrieve the previous status if any (looking for SUCCESS-HC and SUCCESS-UPDT)
+    - for each VIOS of the tuple, check the SSP name and node status
+    - stop the SSP if necessary
+    - perform the updateios operation
+    - wait for the copy to finish
+    - start the SSP if necessary
 
     arguments:
-        module  (dict): The Ansible module
+        module          (dict): The Ansible module
+        targets_list    (list): Target tuple list of VIOS
+        vios_status     (dict): provided previous status for each tuple
+        time_limit       (str): Date and time to perform tuple update
+    note:
+        Set the update status in results['status'][vios_key].
     return:
         none
     """
@@ -750,7 +816,7 @@ def nim_updateios(module, targets_list, vios_status, time_limit):
             results['status'][vios_key] = "SKIPPED-TIMEOUT"
             return
 
-        if module.params('action') in ['install', 'reject', 'cleanup']:
+        if module.params('action') in ['install', 'reject', 'cleanup'] and module.params['manage_ssp']:
             # check if SSP is defined for this VIOSes tuple.
             if not check_vios_ssp_status(module, target_tuple):
                 msg = "{0} VIOSes skipped (bad SSP status)".format(vios_key)
@@ -765,7 +831,6 @@ def nim_updateios(module, targets_list, vios_status, time_limit):
                 continue
 
         results['status'][vios_key] = "SUCCESS-UPDT"
-        # TODO VRO should we simulate a success if preview is set? Is there a preview mode in updateios NIM operation?
         # DEBUG-Begin : Uncomment for testing without effective update operation
         # results['meta'][vios_key]['messages'].append('Warning: testing without effective update operation')
         # results['meta'][vios_key]['messages'].append('NIM Command: {0} '.format(updateios_cmd))
@@ -784,7 +849,7 @@ def nim_updateios(module, targets_list, vios_status, time_limit):
 
             # if needed stop the SSP for the VIOS
             restart_needed = False
-            if tuple_len == 2 and module.params('action') in ['install', 'reject', 'cleanup']:
+            if tuple_len == 2 and module.params('action') in ['install', 'reject', 'cleanup'] and module.params['manage_ssp']:
                 if not ssp_stop_start(module, target_tuple, vios_key, vios, 'stop'):
                     results['status'][vios_key] = err_label
                     break  # cannot continue
@@ -811,6 +876,7 @@ def nim_updateios(module, targets_list, vios_status, time_limit):
                 results['changed'] = True
 
             # if needed restart the SSP for the VIOS
+            # TODO check if updateios returns before it finishes
             if restart_needed:
                 if not ssp_stop_start(module, target_tuple, vios_key, vios, 'start'):
                     results['status'][vios_key] = err_label
@@ -831,14 +897,15 @@ def main():
             action=dict(choices=['install', 'commit', 'reject', 'cleanup', 'remove'],
                         required=True, type='str'),
             targets=dict(required=True, type='list', elements='str'),
-            filesets=dict(required=False, type='str'),
-            installp_bundle=dict(required=False, type='str'),
-            lpp_source=dict(required=False, type='str'),
-            accept_licenses=dict(required=False, type='bool', default=True),
-            preview=dict(required=False, type='bool', default=True),
-            time_limit=dict(required=False, type='str'),
-            vios_status=dict(required=False, type='dict'),
-            nim_node=dict(required=False, type='dict')
+            filesets=dict(type='str'),
+            installp_bundle=dict(type='str'),
+            lpp_source=dict(type='str'),
+            accept_licenses=dict(type='bool', default=True),
+            manage_ssp=dict(type='bool', default=False),
+            preview=dict(type='bool', default=True),
+            time_limit=dict(type='str'),
+            vios_status=dict(type='dict'),
+            nim_node=dict(type='dict')
         ),
         required_if=[
             ['action', 'install', ['lpp_source']],
@@ -871,7 +938,6 @@ def main():
 
     vios_status = {}
     action = module.params['action']
-    targets = module.params['targets']
 
     # Get and check parameters
     if module.params['vios_status']:
@@ -882,8 +948,8 @@ def main():
         param_one_of(['installp_bundle', 'filesets'])
     else:
         if module.params['filesets'] or module.params['installp_bundle']:
-            msg = 'action is {0}: discarding installp_bundle or filesets attribute'.format(action)
-            module.log(msg + ': attribute filesets "{0}" and installp_bundle "{1}"'
+            msg = 'action is {0}: discarding installp_bundle and filesets attribute'.format(action)
+            module.log(msg + ', got: filesets:"{0}" and installp_bundle:"{1}"'
                        .format(module.params['filesets'], module.params['installp_bundle']))
             results['meta']['messages'].append(msg)
 
@@ -904,12 +970,13 @@ def main():
     if module.params['nim_node']:
         results['nim_node'] = module.params['nim_node']
     if 'vios' not in module.params['nim_node']:
-        results['nim_node'].update({type: get_nim_type_info(module, 'vios')})
+        results['nim_node'].update({'vios': get_nim_type_info(module, 'vios')})
 
     # check targets are valid NIM clients
-    results['targets'] = check_vios_targets(module, targets)
+    results['targets'] = check_vios_targets(module, module.params['targets'])
+
     if not results['targets']:
-        module.log('Warning: Empty target list, targets: \'{0}\''.format(targets))
+        module.log('Warning: Empty target list, targets: \'{0}\''.format(module.params['targets']))
         results['msg'] = 'Empty target list, please check their NIM states and they are reacheable.'
         module.exit_json(**results)
 
@@ -919,20 +986,6 @@ def main():
         results['status'][vios_key] = ''  # first time init
         results['meta'][vios_key] = {'messages': []}  # first time init
 
-    # Get VIOS interface info in case we need to connect using c_rsh
-    for target in results['targets']:
-        for vios in target:
-            if 'if1' in module.params['nim_node']['vios'][vios]:
-                fields = results['nim_node']['vios'][vios]['if1'].split(' ')
-                if len(fields) >= 2:
-                    results['nim_node']['vios'][vios]['vios_ip'] = fields[1]
-                    continue
-            if 'vios_ip' not in module.params['nim_node']['vios']:
-                msg = 'Cannot get vios {0}\'s interface address (from lsnim -l command). Please check its NIM setting.'.format(vios)
-                module.log('[WARNING] ' + msg)
-                results['meta']['messages'].append('Warning: ' + msg)
-                # TODO If no IP address, should we do something else, or wait for failure if c_rsh is needed?
-
     # Perfom the update
     nim_updateios(module, results['targets'], vios_status, time_limit)
 
@@ -940,9 +993,13 @@ def main():
         module.log('NIM updateios operation: status table is empty')
         results['meta']['messages'].append('Warning: status table is empty, returning initial vios_status.')
         results['status'] = vios_status
-
-    # Exit
-    results['msg'] = "NIM updateios operation completed. See status and meta for details."
+        results['msg'] = "NIM updateios operation completed. See meta data for details."
+    else:
+        target_errored = [key for key, val in results['status'].items() if 'FAILURE' in val]
+        if len(target_errored):
+            results['msg'] = "NIM updateios operation failed for {0}. See status and meta for details.".format(target_errored)
+        else:
+            results['msg'] = "NIM updateios operation completed. See status and meta for details."
     module.exit_json(**results)
 
 

--- a/plugins/modules/nim_vios_alt_disk.py
+++ b/plugins/modules/nim_vios_alt_disk.py
@@ -109,17 +109,12 @@ msg:
     description: Status information.
     returned: always
     type: str
-targets:
-    description: List of VIOS tuples.
-    returned: always
-    type: list
-    elements: dict
 nim_node:
     description: NIM node info.
     returned: always
     type: dict
 status:
-    description: Status for each VIOS (dicionnary key).
+    description: Status for each VIOS tuples (dictionary key).
     returned: always
     type: dict
 '''
@@ -1278,7 +1273,6 @@ def main():
 
     vios_status = {}
     targets_altdisk_status = {}
-    target_list = []
 
     # =========================================================================
     # Build nim node info
@@ -1328,7 +1322,6 @@ def main():
         module.log('VIOS Alternate disk operation: Error getting the status')
         targets_altdisk_status = vios_status
 
-    results['targets'] = target_list
     results['nim_node'] = NIM_NODE
     results['status'] = targets_altdisk_status
     results['output'] = OUTPUT

--- a/plugins/modules/nim_vios_alt_disk.py
+++ b/plugins/modules/nim_vios_alt_disk.py
@@ -70,16 +70,15 @@ options:
     default: nearest
   force:
     description:
-    - Forces removal of any existing alternate disk copy on target disk.
+    - Forces removal of any existing alternate disk copy on target disks.
+    - Stops any active rootvg mirroring during the alternate disk copy.
     type: bool
     default: no
 notes:
   - C(alt_disk_copy) only backs up mounted file systems. Mount all file
     systems that you want to back up.
-  - copy is performed only on one alternate hdisk even if the rootvg
-    contains multiple hdisks
-  - error if several C(altinst_rootvg) exist for cleanup operation in
-    automatic mode
+  - when no target is specified, copy is performed to only one alternate
+    disk even if the rootvg contains multiple disks
 '''
 
 EXAMPLES = r'''
@@ -998,6 +997,7 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
     """
     global NIM_NODE
     global OUTPUT
+    global PARAMS
     global results
 
     module.debug('action: {0}, targets: {1}, vios_status: {2}'
@@ -1081,6 +1081,15 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
                 nb_copies = len(copies_h.keys())
 
                 if nb_copies > 1:
+                    if not PARAMS['force']:
+                        altdisk_op_tab[vios_key] = "{0} rootvg is mirrored on {1}"\
+                                                   .format(err_label, vios)
+                        OUTPUT.append('    The rootvg is mirrored on {0} and force option is not set'
+                                      .format(vios))
+                        module.log('The rootvg is mirrored on {0} and force option is not set'
+                                   .format(vios))
+                        break
+
                     OUTPUT.append('    Stop mirroring on {0}'.format(vios))
                     module.log('[WARNING] Stop mirror on {0}'.format(vios))
 

--- a/plugins/modules/nim_vios_alt_disk.py
+++ b/plugins/modules/nim_vios_alt_disk.py
@@ -34,13 +34,11 @@ options:
     required: true
   targets:
     description:
-    - NIM VIOS target.
-    - Use a tuple format with the 1st element the VIOS and the 2nd element
-      the disk used for the alternate disk copy.
-      "vios1,disk1,vios2,disk2" for dual VIOSes.
-      "vios1,disk1" for single VIOS.
+    - NIM VIOS targets.
+    - Use a dictionary format, with the key being the VIOS NIM name and the
+      value being the list of disks used for the alternate disk copy.
     type: list
-    elements: str
+    elements: dict
     required: true
   time_limit:
     description:
@@ -85,19 +83,26 @@ notes:
 '''
 
 EXAMPLES = r'''
-- name: Perform an alternate disk copy of the rootvg to hdisk1
+- name: Perform an alternate disk copy of the rootvg to hdisk1 on nimvios01
   nim_vios_alt_disk:
     action: alt_disk_copy
     targets:
-    - nimvios01,hdisk1
+    - nimvios01: [hdisk1]
 
 - name: Perform an alternate disk copy of the rootvg to the smallest disk that can be selected
   nim_vios_alt_disk:
     action: alt_disk_copy
     disk_size_policy: minimize
     targets:
-    - nimvios01,,nimvios02,
-    - nimvios03,
+    - nimvios01: []
+      nimvios02: []
+    - nimvios03: []
+
+- name: Perform a cleanup of any existing alternate disk copy on nimvios01
+  nim_vios_alt_disk:
+    action: alt_disk_clean
+    targets:
+    - nimvios01: []
 '''
 
 RETURN = r'''
@@ -109,7 +114,7 @@ targets:
     description: List of VIOS tuples.
     returned: always
     type: list
-    elements: str
+    elements: dict
 nim_node:
     description: NIM node info.
     returned: always
@@ -288,85 +293,48 @@ def check_vios_targets(module, targets):
     Check the list of VIOS targets.
 
     A target name can be of the following forms:
-        vios1,altdisk1
-        vios1,altdisk1,vios2,altdisk2
-    altdisk can be omitted if one wants to use the automatic discovery,
+        - vios1: [altdisk1]
+        - vios1: [altdisk1,altdisk2]
+          vios2: [altdisk2]
+    altdisk can be an empty list if one wants to use the automatic discovery,
     in which case the first available disk with enough space is used.
 
     arguments:
-        targets: list of tuples of NIM name of vios machine and
-                    associated alternate disk
+        targets: list of dictionaries of VIOS NIM names and
+                    associated alternate disks
 
-    return: the list of the existing vios tuples matching the target list
+    return: True iff all targets are valid NIM VIOS objects and are reachable
     """
     global NIM_NODE
 
-    vios_list = {}
-    vios_list_tuples_res = []
-
     # ===========================================
-    # Build targets list
+    # Check targets
     # ===========================================
-    for vios_tuple in targets:
-        module.debug('Checking vios_tuple: {0}'.format(vios_tuple))
+    for vios_dict in targets:
+        if len(vios_dict) > 2:
+            OUTPUT.append('Malformed VIOS targets {0}. Dictionary should contain 1 or 2 elements.'
+                          .format(vios_dict))
+            module.log('Malformed VIOS targets {0}. Dictionary should contain 1 or 2 elements.'
+                       .format(vios_dict))
+            return False
 
-        tuple_elts = list(vios_tuple.split(','))
-        tuple_len = len(tuple_elts)
+        for vios in vios_dict:
+            # check vios is known by the NIM master - if not ignore it
+            # because it can concern another ansible host (nim master)
+            if vios not in NIM_NODE['nim_vios']:
+                module.log('skipping {0} as VIOS not known by the NIM master.'
+                           .format(vios))
+                return False
 
-        if tuple_len != 2 and tuple_len != 4:
-            OUTPUT.append('Malformed VIOS targets {0}. Tuple {1} should be a 2 or 4 elements.'
-                          .format(targets, tuple_elts))
-            module.log('Malformed VIOS targets {0}. Tuple {1} should be a 2 or 4 elements.'
-                       .format(targets, tuple_elts))
-            return None
-
-        # check vios does not already exist in the target list
-        if tuple_elts[0] in vios_list or (tuple_len == 4 and (tuple_elts[2] in vios_list
-                                                              or tuple_elts[0] == tuple_elts[2])):
-            OUTPUT.append('Malformed VIOS targets {0}. Duplicated VIOS'
-                          .format(targets))
-            module.log('Malformed VIOS targets {0}. Duplicated VIOS'
-                       .format(targets))
-            return None
-
-        # check vios is known by the NIM master - if not ignore it
-        # because it can concern an other ansible host (nim master)
-        if tuple_elts[0] not in NIM_NODE['nim_vios'] or (tuple_len == 4
-                                                         and tuple_elts[2] not in NIM_NODE['nim_vios']):
-            module.log('skipping {0} as VIOS not known by the NIM master.'
-                       .format(vios_tuple))
-            continue
-
-        # check vios connectivity
-        res = 0
-        id = 0
-        while id < tuple_len:
-            elem = tuple_elts[id]
+            # check vios connectivity
             cmd = ['true']
-            ret, stdout, stderr = nim_exec(module, NIM_NODE['nim_vios'][elem]['vios_ip'], cmd)
+            ret, stdout, stderr = nim_exec(module, NIM_NODE['nim_vios'][vios]['vios_ip'], cmd)
             if ret != 0:
-                module.log('skipping {0}: cannot reach {1} with c_rsh: {2}, {3}, {4}'
-                           .format(vios_tuple, elem, res, stdout, stderr))
-                res = 1
-            id += 2
-        if res != 0:
-            continue
+                module.log('skipping {0}: cannot reach with c_rsh: {1}, {2}, {3}'
+                           .format(vios, ret, stdout, stderr))
+                return False
 
-        # fill vios_list dictionary
-        if tuple_len == 4:
-            vios_list[tuple_elts[0]] = tuple_elts[1]
-            vios_list[tuple_elts[2]] = tuple_elts[3]
-            # vios_list = vios_list.extend([tuple_elts[0], tuple_elts[1]])
-            my_tuple = (tuple_elts[0], tuple_elts[1], tuple_elts[2],
-                        tuple_elts[3])
-            vios_list_tuples_res.append(tuple(my_tuple))
-        else:
-            vios_list[tuple_elts[0]] = tuple_elts[1]
-            # vios_list.append(tuple_elts[0])
-            my_tuple = (tuple_elts[0], tuple_elts[1])
-            vios_list_tuples_res.append(tuple(my_tuple))
-
-    return vios_list_tuples_res
+    return True
 
 
 def get_pvs(module, vios):
@@ -470,13 +438,20 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
     pvs = {}
     used_pv = []
 
-    for vios in vios_dict:
-        module.debug('action: {0}, vios_dict[{1}]: {2}, vios_key: {3}'
-                     .format(action, vios, vios_dict[vios], vios_key))
+    for vios, hdisks in vios_dict.items():
+        module.debug('action: {0}, vios: {1}, hdisks: {2}, vios_key: {3}'
+                     .format(action, vios, hdisks, vios_key))
 
-        OUTPUT.append('    Check the alternate disk {0} on {1}'.format(vios_dict[vios], vios))
+        OUTPUT.append('    Check the alternate disks {0} on {1}'.format(hdisks, vios))
 
         err_label = "FAILURE-ALTDC"
+
+        # check value is a list
+        if not isinstance(hdisks, list):
+            altdisk_op_tab[vios_key] = "{0} value is not a list for {1}"\
+                                       .format(err_label, vios)
+            return 1
+
         # check rootvg
         if rootvg_info[vios]["status"] != 0:
             altdisk_op_tab[vios_key] = "{0} wrong rootvg state on {1}"\
@@ -486,7 +461,7 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
         # Clean existing altinst_rootvg if needed
         if PARAMS['force']:
             OUTPUT.append('    Remove altinst_rootvg from {0} of {1}'
-                          .format(vios_dict[vios], vios))
+                          .format(hdisks, vios))
 
             vios_ip = NIM_NODE['nim_vios'][vios]['vios_ip']
 
@@ -500,19 +475,20 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
                 module.log('Failed to remove altinst_rootvg on {0}: {1}'
                            .format(vios, stderr))
             else:
-                cmd = ['/usr/sbin/chpv', '-C', vios_dict[vios]]
-                ret, stdout, stderr = nim_exec(module, vios_ip, cmd)
-                if ret != 0:
-                    altdisk_op_tab[vios_key] = "{0} to clear altinst_rootvg from {1} on {2}"\
-                                               .format(err_label, vios_dict[vios], vios)
-                    OUTPUT.append('    Failed to clear altinst_rootvg from disk {0} on {1}: {2}'
-                                  .format(vios_dict[vios], vios, stderr))
-                    module.log('Failed to clear altinst_rootvg from disk {0} on {1}: {2}'
-                               .format(vios_dict[vios], vios, stderr))
-                    continue
-                OUTPUT.append('    Clear altinst_rootvg from disk {0}: Success'
-                              .format(vios_dict[vios]))
-                results['changed'] = True
+                for hdisk in hdisks:
+                    cmd = ['/usr/sbin/chpv', '-C', hdisk]
+                    ret, stdout, stderr = nim_exec(module, vios_ip, cmd)
+                    if ret != 0:
+                        altdisk_op_tab[vios_key] = "{0} to clear altinst_rootvg from {1} on {2}"\
+                                                   .format(err_label, hdisk, vios)
+                        OUTPUT.append('    Failed to clear altinst_rootvg from disk {0} on {1}: {2}'
+                                      .format(hdisk, vios, stderr))
+                        module.log('Failed to clear altinst_rootvg from disk {0} on {1}: {2}'
+                                   .format(hdisk, vios, stderr))
+                        continue
+                    OUTPUT.append('    Clear altinst_rootvg from disk {0}: Success'
+                                  .format(hdisk))
+                    results['changed'] = True
 
         # get pv list
         pvs = get_pvs(module, vios)
@@ -522,14 +498,14 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
             return 1
 
         # check an alternate disk does not already exist
-        for hdisk in pvs:
-            if pvs[hdisk]['vg'] == 'altinst_rootvg':
+        for pv in pvs:
+            if pvs[pv]['vg'] == 'altinst_rootvg':
                 altdisk_op_tab[vios_key] = "{0} an alternate disk ({1}) already exists on {2}"\
-                                           .format(err_label, hdisk, vios)
+                                           .format(err_label, pv, vios)
                 OUTPUT.append('    An alternate disk is already available on disk {0} on {1}'
-                              .format(hdisk, vios))
+                              .format(pv, vios))
                 module.log('An alternate disk is already available on disk {0} on {1}'
-                           .format(hdisk, vios))
+                           .format(pv, vios))
                 return 1
 
         pvs = get_free_pvs(module, vios)
@@ -546,7 +522,8 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
         used_size = rootvg_info[vios]["used_size"]
         rootvg_size = rootvg_info[vios]["rootvg_size"]
         # in auto mode, find the first alternate disk available
-        if vios_dict[vios] == "":
+        if not hdisks:
+            selected_disk = ""
             prev_disk = ""
             diffsize = 0
             prev_diffsize = 0
@@ -560,7 +537,7 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
 
                 # smallest disk that can be selected
                 if PARAMS['disk_size_policy'] == 'minimize':
-                    vios_dict[vios] = hdisk
+                    selected_disk = hdisk
                     if pvs[hdisk]['pvid'] != 'none':
                         used_pv.append(pvs[hdisk]['pvid'])
                     break
@@ -568,14 +545,13 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
                 diffsize = pvs[hdisk]['size'] - rootvg_size
                 # matching disk size
                 if diffsize == 0:
-                    vios_dict[vios] = hdisk
+                    selected_disk = hdisk
                     if pvs[hdisk]['pvid'] != 'none':
                         used_pv.append(pvs[hdisk]['pvid'])
                     break
 
                 if diffsize > 0:
                     # diffsize > 0: first disk found bigger than the rootvg disk
-                    selected_disk = ""
                     if PARAMS['disk_size_policy'] == 'upper':
                         selected_disk = hdisk
                     elif PARAMS['disk_size_policy'] == 'lower':
@@ -593,7 +569,6 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
                         else:
                             selected_disk = prev_disk
 
-                    vios_dict[vios] = selected_disk
                     if pvs[selected_disk]['pvid'] != 'none':
                         used_pv.append(pvs[selected_disk]['pvid'])
                     break
@@ -603,15 +578,15 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
                 prev_diffsize = diffsize
                 continue
 
-            if vios_dict[vios] == "":
-                if prev_disk != "":
+            if not selected_disk:
+                if prev_disk:
                     # Best Can Do...
-                    vios_dict[vios] = prev_disk
-                    if pvs[prev_disk]['pvid'] != 'none':
-                        used_pv.append(pvs[prev_disk]['pvid'])
+                    selected_disk = prev_disk
+                    if pvs[selected_disk]['pvid'] != 'none':
+                        used_pv.append(pvs[selected_disk]['pvid'])
                 else:
-                    altdisk_op_tab[vios_key] = "{0} to find an alternate disk {1} on {2}"\
-                                               .format(err_label, vios_dict[vios], vios)
+                    altdisk_op_tab[vios_key] = "{0} to find an alternate disk on {1}"\
+                                               .format(err_label, vios)
                     OUTPUT.append('    No available alternate disk with size greater than {0} MB'
                                   ' found on {1}'.format(rootvg_size, vios))
                     module.log('No available alternate disk with size greater than {0} MB'
@@ -619,44 +594,47 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, rootvg_info, altdisk
                     return 1
 
             module.debug('Selected disk on vios {0} is {1} (select mode: {2})'
-                         .format(vios, vios_dict[vios], PARAMS['disk_size_policy']))
+                         .format(vios, selected_disk, PARAMS['disk_size_policy']))
+            vios_dict[vios].append(selected_disk)
 
-        # hdisk specified by the user
+        # hdisks specified by the user
         else:
-            # check the specified hdisk is large enough
-            hdisk = vios_dict[vios]
-            if hdisk in pvs:
+            tot_size = 0
+            for hdisk in hdisks:
+                if hdisk not in pvs:
+                    altdisk_op_tab[vios_key] = "{0} disk {1} is not available on {2}"\
+                                               .format(err_label, hdisk, vios)
+                    OUTPUT.append('    Alternate disk {0} is not available on {1}'
+                                  .format(hdisk, vios))
+                    module.log('Alternate disk {0} is either not found or not available on {1}'
+                               .format(hdisk, vios))
+                    return 1
                 if pvs[hdisk]['pvid'] in used_pv:
                     altdisk_op_tab[vios_key] = "{0} alternate disk {1} already"\
                                                " used on the mirror VIOS"\
-                                               .format(err_label, vios_dict[vios])
+                                               .format(err_label, hdisk)
                     module.log('Alternate disk {0} already used on the mirror VIOS.'
-                               .format(vios_dict[vios]))
+                               .format(hdisk))
                     return 1
-                if pvs[vios_dict[vios]]['size'] >= rootvg_size:
+                tot_size += pvs[hdisk]['size']
+
+            # check the specified hdisks are large enough
+            if tot_size >= rootvg_size:
+                for hdisk in hdisks:
                     if pvs[hdisk]['pvid'] != 'none':
                         used_pv.append(pvs[hdisk]['pvid'])
-                else:
-                    if pvs[vios_dict[vios]]['size'] >= used_size:
+            else:
+                if tot_size >= used_size:
+                    for hdisk in hdisks:
                         if pvs[hdisk]['pvid'] != 'none':
                             used_pv.append(pvs[hdisk]['pvid'])
-                        module.log('[WARNING] Alternate disk {0} smaller than the current rootvg.'
-                                   .format(vios_dict[vios]))
-                    else:
-                        altdisk_op_tab[vios_key] = "{0} alternate disk {1} too small on {2}"\
-                                                   .format(err_label, vios_dict[vios], vios)
-                        module.log('Alternate disk {0} too small ({1} < {2}) on {3}.'
-                                   .format(vios_dict[vios], pvs[vios_dict[vios]]['size'],
-                                           rootvg_size, vios))
-                        return 1
-            else:
-                altdisk_op_tab[vios_key] = "{0} disk {1} is not available on {2}"\
-                                           .format(err_label, vios_dict[vios], vios)
-                OUTPUT.append('    Alternate disk {0} is not available on {1}'
-                              .format(vios_dict[vios], vios))
-                module.log('Alternate disk {0} is either not found or not available on {1}'
-                           .format(vios_dict[vios], vios))
-                return 1
+                    module.log('[WARNING] Alternate disks smaller than the current rootvg.')
+                else:
+                    altdisk_op_tab[vios_key] = "{0} alternate disks too small on {1}"\
+                                               .format(err_label, vios)
+                    module.log('Alternate disks too small ({0} < {1}) on {2}.'
+                               .format(tot_size, rootvg_size, vios))
+                    return 1
 
     # Disks found
     return 0
@@ -852,7 +830,7 @@ def check_rootvg(module, vios):
     return vg_info
 
 
-def check_valid_altdisk(module, action, vios, vios_dict, vios_key, altdisk_op_tab, err_label):
+def check_valid_altdisks(module, action, vios, hdisks, vios_key, altdisk_op_tab, err_label):
     """
     Check a valid alternate disk that
     - exists,
@@ -864,59 +842,53 @@ def check_valid_altdisk(module, action, vios, vios_dict, vios_key, altdisk_op_ta
         altdisk_op_tab[vios_key] = "SUCCESS-ALTDC"
 
     return:
-        0 if alternate disk is found
-        1 otherwise
+        True  if alternate disk is found
+        False otherwise
     """
     global NIM_NODE
     global OUTPUT
 
-    module.debug('action: {0}, vios_dict[{1}]: {2}, vios_key: {3}'
-                 .format(action, vios, vios_dict[vios], vios_key))
+    module.debug('action: {0}, vios: {1}, hdisks: {2}, vios_key: {3}'
+                 .format(action, vios, hdisks, vios_key))
 
-    OUTPUT.append('    Check the alternate disk {0} on {1}'.format(vios_dict[vios], vios))
+    OUTPUT.append('    Check the alternate disks {0} on {1}'.format(hdisks, vios))
 
     pvs = get_pvs(module, vios)
     if (pvs is None) or (not pvs):
         altdisk_op_tab[vios_key] = "{0} to get the list of PVs on {1}"\
                                    .format(err_label, vios)
-        return 1
+        return False
 
-    if vios_dict[vios] != "":
-        if vios_dict[vios] in pvs and pvs[vios_dict[vios]]['vg'] == 'altinst_rootvg':
-            return 0
-        else:
-            altdisk_op_tab[vios_key] = "{0} disk {1} is not an alternate install rootvg on {2}"\
-                                       .format(err_label, vios_dict[vios], vios)
-            OUTPUT.append('    Specified disk {0} is not an alternate install rootvg on {1}'
-                          .format(vios_dict[vios], vios))
-            module.log('Specified disk {0} is not an alternate install rootvg on {1}'
-                       .format(vios_dict[vios], vios))
-            return 1
+    if not isinstance(hdisks, list):
+        altdisk_op_tab[vios_key] = "{0} value is not a list for {1}"\
+                                   .format(err_label, vios)
+        return False
+
+    if hdisks:
+        # Check that all specified disks exist and belong to altinst_rootvg
+        for hdisk in hdisks:
+            if (hdisk not in pvs) or (pvs[hdisk]['vg'] != 'altinst_rootvg'):
+                altdisk_op_tab[vios_key] = "{0} disk {1} is not an alternate install rootvg on {2}"\
+                                           .format(err_label, hdisk, vios)
+                OUTPUT.append('    Specified disk {0} is not an alternate install rootvg on {1}'
+                              .format(hdisk, vios))
+                module.log('Specified disk {0} is not an alternate install rootvg on {1}'
+                           .format(hdisk, vios))
+                return False
     else:
-        # check there is one and only one alternate install rootvg
-        for hdisk in pvs.keys():
-            if pvs[hdisk]['vg'] == 'altinst_rootvg':
-                if vios_dict[vios]:
-                    altdisk_op_tab[vios_key] = "{0} there are several alternate"\
-                                               " install rootvg on {1}"\
-                                               .format(err_label, vios)
-                    OUTPUT.append('    There are several alternate install rootvg on {0}: {1} and {2}'
-                                  .format(vios, vios_dict[vios], hdisk))
-                    module.log('There are several alternate install rootvg on {0}: {1} and {2}'
-                               .format(vios, vios_dict[vios], hdisk))
-                    vios_dict[vios] = ""    # reset previously set hdisk
-                    return 1
-                else:
-                    vios_dict[vios] = hdisk
-        if vios_dict[vios]:
-            return 0
-        else:
+        # Retrieve the list of disks that belong to altinst_rootvg
+        for pv in pvs.keys():
+            if pvs[pv]['vg'] == 'altinst_rootvg':
+                hdisks.append(pv)
+        if not hdisks:
             OUTPUT.append('    There is no alternate install rootvg on {0}'.format(vios))
             module.log('There is no alternate install rootvg on {0}'.format(vios))
-            return 1
+            return False
+
+    return True
 
 
-def wait_altdisk_install(module, vios, vios_dict, vios_key, altdisk_op_tab, err_label):
+def wait_altdisk_install(module, vios, hdisks, vios_key, altdisk_op_tab, err_label):
     """
     Wait for the alternate disk copy operation to finish.
 
@@ -932,10 +904,10 @@ def wait_altdisk_install(module, vios, vios_dict, vios_key, altdisk_op_tab, err_
     """
     global OUTPUT
 
-    module.debug('vios_dict[{0}]: {1}, vios_key: {2}'
-                 .format(vios, vios_dict[vios], vios_key))
+    module.debug('vios: {0}, hdisks: {1}, vios_key: {2}'
+                 .format(vios, hdisks, vios_key))
     module.log('Waiting completion of alt_disk copy {0} on {1}...'
-               .format(vios_dict[vios], vios))
+               .format(hdisks, vios))
 
     # if there is no progress in nim operation "info" attribute for more than
     # 30 minutes we time out: 180 * 10s = 30 min
@@ -994,15 +966,15 @@ def wait_altdisk_install(module, vios, vios_dict, vios_key, altdisk_op_tab, err_
 
         if wait_time % 60 == 0:
             module.log('Waiting completion of alt_disk copy {0} on {1}... {2} minute(s)'
-                       .format(vios_dict[vios], vios, wait_time / 60))
+                       .format(hdisks, vios, wait_time / 60))
 
     # timed out before the end of alt_disk_install
     altdisk_op_tab[vios_key] = "{0} alternate disk copy of {1} blocked on {2}: NIM operation blocked"\
                                .format(err_label, vios, nim_info)
     OUTPUT.append('    Alternate disk copy of {0} blocked on {1}: {2}'
-                  .format(vios_dict[vios], vios, nim_info))
+                  .format(hdisks, vios, nim_info))
     module.log('Alternate disk copy of {0} blocked on {1}: {2}'
-               .format(vios_dict[vios], vios, nim_info))
+               .format(hdisks, vios, nim_info))
 
     return -1
 
@@ -1033,22 +1005,14 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
 
     rootvg_info = {}
     altdisk_op_tab = {}
-    vios_key = []
-    for target_tuple in targets:
-        module.debug('action: {0} for target_tuple: {1}'
-                     .format(action, target_tuple))
 
-        vios_dict = {}
-        tup_len = len(target_tuple)
-        vios1 = target_tuple[0]
-        vios2 = ""
-        vios_dict[vios1] = target_tuple[1]
-        if tup_len == 4:
-            vios2 = target_tuple[2]
-            vios_dict[vios2] = target_tuple[3]
-            vios_key = "{0}-{1}".format(vios1, vios2)
-        else:
-            vios_key = vios1
+    for vios_dict in targets:
+        module.debug('action: {0} for target: {1}'.format(action, vios_dict))
+
+        # sort VIOSes by name so that the key matches
+        vios_list = list(vios_dict.keys())
+        vios_list.sort()
+        vios_key = '-'.join(vios_list)
 
         module.debug('vios_key: {0}'.format(vios_key))
 
@@ -1092,20 +1056,20 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
             if ret != 0:
                 continue
 
-        for vios in vios_dict:
+        for vios, hdisks in vios_dict.items():
 
             # set the error label to be used in sub routines
             if action == 'alt_disk_copy':
                 err_label = "FAILURE-ALTDCOPY1"
-                if vios != vios1:
+                if vios != vios_list[0]:
                     err_label = "FAILURE-ALTDCOPY2"
             elif action == 'alt_disk_clean':
                 err_label = "FAILURE-ALTDCLEAN1"
-                if vios != vios1:
+                if vios != vios_list[0]:
                     err_label = "FAILURE-ALTDCLEAN2"
 
-            OUTPUT.append('    Using {0} as alternate disk on {1}'.format(vios_dict[vios], vios))
-            module.log('Using {0} as alternate disk on {1}'.format(vios_dict[vios], vios))
+            OUTPUT.append('    Using {0} as alternate disks on {1}'.format(hdisks, vios))
+            module.log('Using {0} as alternate disks on {1}'.format(hdisks, vios))
 
             vios_ip = NIM_NODE['nim_vios'][vios]['vios_ip']
 
@@ -1151,22 +1115,21 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
                 # alt_disk_copy
                 cmd = ['nim', '-o', 'alt_disk_install',
                        '-a', 'source=rootvg',
-                       '-a', 'disk=' + vios_dict[vios],
+                       '-a', 'disk=' + ' '.join(hdisks),
                        '-a', 'set_bootlist=no',
                        '-a', 'boot_client=no',
                        vios]
                 ret_altdc, stdout, stderr = module.run_command(cmd)
                 if ret_altdc != 0:
                     altdisk_op_tab[vios_key] = "{0} to copy {1} on {2}"\
-                                               .format(err_label,
-                                                       vios_dict[vios], vios)
+                                               .format(err_label, hdisks, vios)
                     OUTPUT.append('    Failed to copy {0} on {1}: {2}'
-                                  .format(vios_dict[vios], vios, stderr))
+                                  .format(hdisks, vios, stderr))
                     module.log('Failed to copy {0} on {1}: {2}'
-                               .format(vios_dict[vios], vios, stderr))
+                               .format(hdisks, vios, stderr))
                 else:
                     # wait till alt_disk_install ends
-                    ret_altdc = wait_altdisk_install(module, vios, vios_dict,
+                    ret_altdc = wait_altdisk_install(module, vios, hdisks,
                                                      vios_key, altdisk_op_tab,
                                                      err_label)
 
@@ -1212,19 +1175,19 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
             elif action == 'alt_disk_clean':
                 OUTPUT.append('    Alternate disk clean on {0}'.format(vios))
 
-                ret = check_valid_altdisk(module, action, vios, vios_dict, vios_key,
-                                          altdisk_op_tab, err_label)
-                if ret != 0:
+                ret = check_valid_altdisks(module, action, vios, hdisks, vios_key,
+                                           altdisk_op_tab, err_label)
+                if not ret:
                     continue
 
-                OUTPUT.append('    Using {0} as alternate disk on {1}'
-                              .format(vios_dict[vios], vios))
-                module.log('Using {0} as alternate disk on {1}'
-                           .format(vios_dict[vios], vios))
+                OUTPUT.append('    Using {0} as alternate disks on {1}'
+                              .format(hdisks, vios))
+                module.log('Using {0} as alternate disks on {1}'
+                           .format(hdisks, vios))
 
                 # First remove the alternate VG
                 OUTPUT.append('    Remove altinst_rootvg from {0} of {1}'
-                              .format(vios_dict[vios], vios))
+                              .format(hdisks, vios))
 
                 cmd = ['/usr/sbin/alt_rootvg_op', '-X', 'altinst_rootvg']
                 ret, stdout, stderr = nim_exec(module, vios_ip, cmd)
@@ -1237,23 +1200,24 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
                                .format(vios, stderr))
                     continue
 
-                # Clears the owning VG from the disk
-                OUTPUT.append('    Clear the owning VG from disk {0} on {1}'
-                              .format(vios_dict[vios], vios))
+                for hdisk in hdisks:
+                    # Clears the owning VG from the disk
+                    OUTPUT.append('    Clear the owning VG from disk {0} on {1}'
+                                  .format(hdisk, vios))
 
-                cmd = ['/usr/sbin/chpv', '-C', vios_dict[vios]]
-                ret, stdout, stderr = nim_exec(module, vios_ip, cmd)
-                if ret != 0:
-                    altdisk_op_tab[vios_key] = "{0} to clear altinst_rootvg from {1} on {2}"\
-                                               .format(err_label, vios_dict[vios], vios)
-                    OUTPUT.append('    Failed to clear altinst_rootvg from disk {0} on {1}: {2}'
-                                  .format(vios_dict[vios], vios, stderr))
-                    module.log('Failed to clear altinst_rootvg from disk {0} on {1}: {2}'
-                               .format(vios_dict[vios], vios, stderr))
-                    continue
+                    cmd = ['/usr/sbin/chpv', '-C', hdisk]
+                    ret, stdout, stderr = nim_exec(module, vios_ip, cmd)
+                    if ret != 0:
+                        altdisk_op_tab[vios_key] = "{0} to clear altinst_rootvg from {1} on {2}"\
+                                                   .format(err_label, hdisk, vios)
+                        OUTPUT.append('    Failed to clear altinst_rootvg from disk {0} on {1}: {2}'
+                                      .format(hdisk, vios, stderr))
+                        module.log('Failed to clear altinst_rootvg from disk {0} on {1}: {2}'
+                                   .format(hdisk, vios, stderr))
+                        continue
 
-                OUTPUT.append('    Clear altinst_rootvg from disk {0}: Success'
-                              .format(vios_dict[vios]))
+                    OUTPUT.append('    Clear altinst_rootvg from disk {0}: Success'
+                                  .format(hdisk))
                 results['changed'] = True
 
     module.debug('altdisk_op_tab: {0}'. format(altdisk_op_tab))
@@ -1269,7 +1233,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            targets=dict(required=True, type='list', elements='str'),
+            targets=dict(required=True, type='list', elements='dict'),
             action=dict(required=True, type='str',
                         choices=['alt_disk_copy', 'alt_disk_clean']),
             time_limit=dict(type='str'),
@@ -1336,27 +1300,24 @@ def main():
     # Perfom check and operation
     # =========================================================================
     ret = check_vios_targets(module, targets)
-    if (ret is None) or (not ret):
-        OUTPUT.append('    Warning: Empty target list')
-        module.log('[WARNING] Empty target list: "{0}"'.format(targets))
+    if not ret:
+        results['output'] = OUTPUT
+        results['msg'] = 'Invalid target list'
+        module.fail_json(**results)
+
+    targets_altdisk_status = alt_disk_action(module, action, targets,
+                                             vios_status, time_limit)
+
+    if targets_altdisk_status:
+        OUTPUT.append('VIOS Alternate disk operation status:')
+        module.log('VIOS Alternate disk operation status:')
+        for vios_key in targets_altdisk_status.keys():
+            OUTPUT.append("    {0} : {1}".format(vios_key, targets_altdisk_status[vios_key]))
+            module.log('    {0} : {1}'.format(vios_key, targets_altdisk_status[vios_key]))
     else:
-        target_list = ret
-        OUTPUT.append('    Targets list: {0}'.format(target_list))
-        module.debug('Targets list: {0}'.format(target_list))
-
-        targets_altdisk_status = alt_disk_action(module, action, target_list,
-                                                 vios_status, time_limit)
-
-        if targets_altdisk_status:
-            OUTPUT.append('VIOS Alternate disk operation status:')
-            module.log('VIOS Alternate disk operation status:')
-            for vios_key in targets_altdisk_status.keys():
-                OUTPUT.append("    {0} : {1}".format(vios_key, targets_altdisk_status[vios_key]))
-                module.log('    {0} : {1}'.format(vios_key, targets_altdisk_status[vios_key]))
-        else:
-            OUTPUT.append('VIOS Alternate disk operation: Error getting the status')
-            module.log('VIOS Alternate disk operation: Error getting the status')
-            targets_altdisk_status = vios_status
+        OUTPUT.append('VIOS Alternate disk operation: Error getting the status')
+        module.log('VIOS Alternate disk operation: Error getting the status')
+        targets_altdisk_status = vios_status
 
     results['targets'] = target_list
     results['nim_node'] = NIM_NODE

--- a/plugins/modules/vios_alt_disk.py
+++ b/plugins/modules/vios_alt_disk.py
@@ -307,8 +307,8 @@ def find_valid_altdisk(module, hdisks, rootvg_info, disk_size_policy, force):
             if tot_size >= used_size:
                 module.log('[WARNING] Alternate disks smaller than the current rootvg.')
             else:
-                results['msg'] = 'Alternate disk {0} too small ({1} < {2}).'\
-                                 .format(hdisk, pvs[hdisk]['size'], rootvg_size)
+                results['msg'] = 'Alternate disks too small ({0} < {1}).'\
+                                 .format(tot_size, rootvg_size)
                 module.fail_json(**results)
 
 


### PR DESCRIPTION
This PR contains:
- nim_vios_alt_disk: add support for multiple target disks, improve documentation, do not return targets
- nim_backup: various fixes, add bosinst_data parameter
- nim_updateios: improve SSP management, use hostname instead of vios_ip in nim_node (from if1), remove reject action and various fixes
- user: add 'modify' state
- group: 'modify' state
