### PR TITLE
Fixed change_passwd_on_login option of user module, because it did not work as expected

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -240,9 +240,9 @@ def change_password(module):
     change_passwd_on_login = module.params['change_passwd_on_login']
 
     if change_passwd_on_login:
-        cmd = "echo \'{user}:{password}\' | chpasswd -ec".format(user=name, password=passwd)
-    else:
         cmd = "echo \'{user}:{password}\' | chpasswd -e".format(user=name, password=passwd)
+    else:
+        cmd = "echo \'{user}:{password}\' | chpasswd -ec".format(user=name, password=passwd)
 
     pass_rc, pass_out, pass_err = module.run_command(cmd, use_unsafe_shell=True)
     if pass_rc != 0:


### PR DESCRIPTION
change_passwd_on_login option of user module did not work as expected: If "false" you had to change the password at next login, if "true" you didn't.
Background: The "-c" option of chpasswd clears all password flags (such as "change at next login"). Therefore this needs to be set only if change_passwd_on_login is set to "false"

