### PR TITLE
New inetd and bootptab roles, nim_viosupgrade replace nim_upgradeios module

### DIFF
--- a/devops/bin/sanity_test.sh
+++ b/devops/bin/sanity_test.sh
@@ -36,14 +36,14 @@ pip3 install pyyaml voluptuous pycodestyle ansible-doc-extractor
 [[ -e $(find test/ -name sanity.txt) ]] && pip install -r $(find test/ -name sanity.txt)
 
 # place the modules in the appropriate folder
-cp $DIR/plugins/modules/*.py $ANSIBLE_DIR/lib/ansible/modules/
+cp $DIR/plugins/modules/[!_]*.py $ANSIBLE_DIR/lib/ansible/modules/
 
 
 set +e
 
 rc=0
 errored=""
-for f in $DIR/plugins/modules/*.py; do
+for f in $DIR/plugins/modules/[!_]*.py; do
     f="${f##*/}"
     m_rc=0
     for version in $PY_VERSIONS; do

--- a/playbooks/demo_nim_viosupgrade.yml
+++ b/playbooks/demo_nim_viosupgrade.yml
@@ -1,0 +1,66 @@
+---
+- name: "viosupgrade operation using NIM"
+  hosts: nimserver
+  gather_facts: no
+  vars:
+    # nim_node_v:        {}
+    target_v:       "quimby-vios2"
+    target_file_v:  "/tmp/mytargetfile"
+    params_altdisk_v:
+      all:
+        resources:              master_net_conf:logdir
+        manage_cluster:         True
+        preview:                True
+      quimby-vios2:
+        ios_mksysb:             vios3-1-1-0_sysb
+        rootvg_clone_disk:      hdisk3
+        backup_file_resource:   quimby-vios2_iosb
+    params_bosinst_v:
+      all:
+        ios_mksysb:             vios3-1-1-0_sysb
+        spotname:               vios3-1-1-0_spot
+        resources:              master_net_conf:logdir
+        manage_cluster:         False
+        preview:                True
+      quimby-vios2:
+        rootvg_install_disk:    hdisk3
+        skip_rootvg_cloning:    Flase
+        backup_file_resource:   quimby-vios2_iosb
+
+  tasks:
+
+   - name: Check vios is ready for viosupgrade
+     nim_viosupgrade:
+       action: get_status
+       targets: "{{ target_v }}"
+     register: result
+     until: result.meta["{{ target_v }}"].stdout.find("ready for a NIM operation") != -1
+     retries: 1
+     delay: 5
+
+   - name: viosupgrade altdisk operation
+     nim_viosupgrade:
+       action: altdisk
+       targets: "{{ target_v }}"
+       viosupgrade_params: "{{ params_altdisk_v }}"
+     register: result
+   - debug: var=result.meta["{{ target_v }}"].stdout.split('\n')
+
+   # - name: viosupgrade bosinst operation
+   #   nim_viosupgrade:
+   #     action: bosinst
+   #     targets: "{{ target_v }}"
+   #     viosupgrade_params: "{{ params_bosinst_v }}"
+   #   register: result
+   # - debug: var=result.meta["{{ target_v }}"].stdout.split('\n')
+
+   - name: Wait for viosupgrade to complete
+     nim_viosupgrade:
+       action: get_status
+       targets: "{{ target_v }}"
+     register: result
+     until: result.status["{{ target_v }}"] != 'ONGOING'
+     retries: 30
+     delay: 120
+   - debug: var=result.meta["{{ target_v }}"].stdout.split('\n')
+

--- a/plugins/modules/_nim_upgradeios.py
+++ b/plugins/modules/_nim_upgradeios.py
@@ -8,14 +8,14 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''
 ---
 author:
 - AIX Development Team (@pbfinley1911)
-module: nim_upgradeios
+module: _nim_upgradeios
 short_description: Use NIM to update a single or a pair of Virtual I/O Servers.
 description:
 - Uses the NIM to perform upgrade to Virtual I/O Server (VIOS) targets tuple.
@@ -226,7 +226,7 @@ notes:
 
 EXAMPLES = r'''
 - name: Perform a backup of nimvios01
-  nim_upgradeios:
+  _nim_upgradeios:
     targets: "(nimvios01)"
     action: backup
 '''

--- a/plugins/modules/nim_upgradeios.py
+++ b/plugins/modules/nim_upgradeios.py
@@ -172,7 +172,6 @@ options:
     - Specifies additional flags to pass to the viosbr command.
     - Can be used with I(action=migrate).
     type: str
-
   mk_image:
     description:
     - Specifies to create the system backup image (mksysb) and create the NIM resource.
@@ -220,9 +219,9 @@ options:
     - Allows to pass along NIM node info from a task to another so that it
       discovers NIM info only one time for all tasks.
     type: dict
-  note:
-    - Debug on NIM master could be done using the following command:
-      B(nim -o showlog -a full_log=yes -a log_type=script vios_target)
+notes:
+  - Debug on NIM master could be done using the following command
+    B(nim -o showlog -a full_log=yes -a log_type=script vios_target)
 '''
 
 EXAMPLES = r'''
@@ -1052,8 +1051,6 @@ def main():
             manage_cluster=dict(type='bool', default=True),
             debug=dict(type='bool', default=False),
         ),
-        required_if=[
-        ],
     )
 
     results = dict(

--- a/plugins/modules/nim_upgradeios.py
+++ b/plugins/modules/nim_upgradeios.py
@@ -220,6 +220,9 @@ options:
     - Allows to pass along NIM node info from a task to another so that it
       discovers NIM info only one time for all tasks.
     type: dict
+  note:
+    - Debug on NIM master could be done using the following command:
+      B(nim -o showlog -a full_log=yes -a log_type=script vios_target)
 '''
 
 EXAMPLES = r'''
@@ -793,6 +796,9 @@ def nim_migvios(module, target_tuple, vios_key, vios):
 
     # Note: the option -a time_limit is not yet supported by migvios
     # time_limit attribute is only valid with the following operations: bos_inst, cust, and alt_disk_install.
+    # nim -o migvios -a spot=jaguar12_ios_mksysb_spot -a ios_mksysb=jaguar12_ios_mksysb -a ios_backup=fake
+    #                -a resolv_conf=resolv_conf -a bosinst_data=bosinst_data_jaguar12_new
+    #                -a boot_client=no -a mk_image=yes jaguar12
     cmd = ['nim', '-Fo', 'migvios']
 
     cmd += ['-a', 'ios_mksysb={0}'.format(mksysb_name)]

--- a/plugins/modules/nim_viosupgrade.py
+++ b/plugins/modules/nim_viosupgrade.py
@@ -206,7 +206,6 @@ meta:
             returned: always
             type: list
             elements: str
-            sample: see below
         <vios>:
             description: Detailed information on the execution on the target vios. Can be 'all'.
             returned: when target is actually a NIM client

--- a/plugins/modules/nim_viosupgrade.py
+++ b/plugins/modules/nim_viosupgrade.py
@@ -169,7 +169,7 @@ EXAMPLES = r'''
     action: get_status
     targets: nimvios01
   register: result
-  until: result.status['nimvios01'] == 'ONGOING'
+  until: result.status['nimvios01'] != 'ONGOING'
   retries: 30
   delay: 120
 

--- a/roles/bootptab/README.md
+++ b/roles/bootptab/README.md
@@ -1,0 +1,7 @@
+# Ansible Role: bootptab
+The [IBM Power Systems AIX](../../README.md) collection provides an [Ansible role](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html), referred to as `bootptab`, which can be used to add or remove entries to the bootptab file.
+
+For guides and reference, see the [Docs Site](https://ibm.github.io/ansible-power-aix/roles.html).
+
+## Copyright
+© Copyright IBM Corporation 2020

--- a/roles/bootptab/defaults/main.yml
+++ b/roles/bootptab/defaults/main.yml
@@ -1,0 +1,12 @@
+# Copyright (c) IBM Corporation 2020
+---
+state: present
+hostname:
+homedir:
+bootfile:
+address:
+mask:
+gateway:
+server:
+hwtype: ethernet
+hwaddr:

--- a/roles/bootptab/meta/main.yml
+++ b/roles/bootptab/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: bootptab
+  author: Paul Finley
+  description: Ansible role for modifying bootptab file on AIX.
+  company: IBM
+
+  license: GPL-3.0-only
+
+  min_ansible_version: 2.9
+
+  platforms:
+  - name: AIX
+    versions:
+    - all
+
+  galaxy_tags: [aix]
+  dependencies: []

--- a/roles/bootptab/tasks/main.yml
+++ b/roles/bootptab/tasks/main.yml
@@ -1,0 +1,23 @@
+# Copyright (c) IBM Corporation 2020
+---
+- name: add bootptab entry
+  ansible.builtin.lineinfile:
+    path: /etc/bootptab
+    regexp: '^{{ hostname }}:'
+    line: '{{ hostname }}:{% if bootfile %}bf={{ bootfile }}:{% endif %}{% if address %}ip={{ address }}:{% endif %}{% if server %}sa={{ server }}:{% endif %}{% if gateway %}gw={{ gateway }}:{% endif %}{% if mask %}sm={{ mask }}:{% endif %}{% if hwaddr %}hw={{ hwaddr }}:{% endif %}{% if hwtype %}ht={{ hwtype }}:{% endif %}{% if homedir %}hd={{ homedir }}:{% endif %}'
+  when: state == 'present' and hostname
+
+- name: remove bootptab entry
+  ansible.builtin.lineinfile:
+    path: /etc/bootptab
+    regexp: '^{{ hostname }}:'
+    state: 'absent'
+  when: state == 'absent' and hostname
+
+- name: enable bootp server
+  include_role:
+    name: ibm.power_aix.inetd
+  vars:
+    - state: enabled
+    - services: [bootps]
+  when: state == 'present' and hostname

--- a/roles/inetd/README.md
+++ b/roles/inetd/README.md
@@ -1,0 +1,7 @@
+# Ansible Role: inetd
+The [IBM Power Systems AIX](../../README.md) collection provides an [Ansible role](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html), referred to as `inetd`, which can be used to enable or disable inetd services, including ftpd, rlogind, rexecd, rshd, telnetd.
+
+For guides and reference, see the [Docs Site](https://ibm.github.io/ansible-power-aix/roles.html).
+
+## Copyright
+© Copyright IBM Corporation 2020

--- a/roles/inetd/defaults/main.yml
+++ b/roles/inetd/defaults/main.yml
@@ -1,0 +1,5 @@
+# Copyright (c) IBM Corporation 2020
+---
+services: []
+state: enabled
+backup: no

--- a/roles/inetd/handlers/main.yml
+++ b/roles/inetd/handlers/main.yml
@@ -1,0 +1,4 @@
+# Copyright (c) IBM Corporation 2020
+---
+- name: restart inetd
+  ansible.builtin.service: name=inetd state=restarted

--- a/roles/inetd/meta/main.yml
+++ b/roles/inetd/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: inetd
+  author: Paul Finley
+  description: Ansible role for enabling/disabling inetd services on AIX.
+  company: IBM
+
+  license: GPL-3.0-only
+
+  min_ansible_version: 2.9
+
+  platforms:
+  - name: AIX
+    versions:
+    - all
+
+  galaxy_tags: [aix]
+  dependencies: []

--- a/roles/inetd/tasks/main.yml
+++ b/roles/inetd/tasks/main.yml
@@ -1,0 +1,25 @@
+# Copyright (c) IBM Corporation 2020
+---
+- name: enable inetd services
+  ansible.builtin.replace:
+    path: /etc/inetd.conf
+    regexp: '^#({{ services | join("\s|") }}\s)'
+    replace: '\1'
+    backup: "{{ backup | bool }}"
+    owner: root
+    group: system
+    mode: 0664
+  when: state == 'enabled' and services
+  notify: restart inetd
+
+- name: disable inetd services
+  ansible.builtin.replace:
+    path: /etc/inetd.conf
+    regexp: '^({{ services | join("\s|") }}\s)'
+    replace: '#\1'
+    backup: "{{ backup | bool }}"
+    owner: root
+    group: system
+    mode: 0664
+  when: state == 'disabled' and services
+  notify: restart inetd


### PR DESCRIPTION
This PR includes:
- inetd and bootptab: new roles
- nim_viosupgrade: new fixes after testing altdisk and bosinst operations
- new playbook to demo nim_viosupgrade
- nim_upgradeios module: deprecated
- sanity_test script: ignore deprecated modules starting with "_" character