### PR TITLE
Use reboot module to restart servers

### DIFF
--- a/playbooks/demo_update-all-hosts.yml
+++ b/playbooks/demo_update-all-hosts.yml
@@ -39,8 +39,6 @@
 
 
   - name: Restart with newest kernel
-    shell: "sleep 5 && reboot"
-    async: 1
-    poll: 0
+    reboot:
     register: output
   - debug: var=output


### PR DESCRIPTION
The reboot module is available since Ansible 2.7 and Ansible for AIX in the AIX Toolbox is version >2.9 already.