### PR TITLE
New reboot and mpio modules + doc + fix Python2 issue

### DIFF
--- a/plugins/action/reboot.py
+++ b/plugins/action/reboot.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020- IBM, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+import time
+
+from datetime import datetime, timedelta
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.plugins.action import ActionBase
+
+
+class TimedOutException(Exception):
+    pass
+
+
+class ActionModule(ActionBase):
+    TRANSFERS_FILES = False
+    _VALID_ARGS = frozenset(('post_reboot_delay', 'pre_reboot_delay', 'test_command', 'reboot_timeout'))
+
+    boot_time_command = 'who -b'
+    reboot_command = 'shutdown -r'
+
+    def __init__(self, *args, **kwargs):
+        super(ActionModule, self).__init__(*args, **kwargs)
+
+    def perform_reboot(self, pre_reboot_delay=None):
+        reboot_result = {}
+        reboot_command = 'shutdown -r'
+
+        if pre_reboot_delay is not None:
+            self._display.vvv("Waiting for pre reboot delay")
+            time.sleep(pre_reboot_delay)
+
+        try:
+            self._display.vvv("System reboot process has started....")
+            reboot_result = self._low_level_execute_command(reboot_command)
+        except AnsibleConnectionFailure:
+            # To handle the case when system closes too quickly, continuing ahead
+            self._display.vvv('AnsibleConnectionFailure has been caught and handled')
+            reboot_result['rc'] = 0
+
+        return reboot_result
+
+    def validate_reboot(self, test_command, reboot_timeout=None, action_kwargs=None):
+        self._display.vvv('Validating reboot....')
+        result = {}
+
+        try:
+            if reboot_timeout is None:
+                reboot_timeout = 300
+
+            self.do_until_success_or_timeout(
+                action_desc="post-reboot test command",
+                reboot_timeout=reboot_timeout,
+                test_command=test_command,
+                action_kwargs=action_kwargs)
+
+            result['rebooted'] = True
+            result['changed'] = True
+            result['msg'] = "System has been rebooted SUCCESSFULLY"
+
+        except TimedOutException:
+            result['failed'] = True
+            result['rebooted'] = True
+            result['msg'] = "Reboot Validation failed due to timeout"
+            return result
+
+        return result
+
+    def do_until_success_or_timeout(self, action_desc, reboot_timeout, test_command, action_kwargs=None):
+        max_end_time = datetime.utcnow() + timedelta(seconds=reboot_timeout)
+        if action_kwargs is None:
+            action_kwargs = {}
+        if test_command is None:
+            test_command = 'whoami'
+
+        while datetime.utcnow() < max_end_time:
+            try:
+                result = self._low_level_execute_command(test_command, sudoable=True)
+                if result['rc'] == 0:
+                    return
+            except Exception as e:
+                if isinstance(e, AnsibleConnectionFailure):
+                    try:
+                        self._connection.reset()
+                    except AttributeError:
+                        pass
+        raise TimedOutException("Connection reset failed while validating the reboot.")
+
+    def run(self, tmp=None, task_vars=None):
+        self._supports_async = True
+
+        post_reboot_delay = self._task.args.get('post_reboot_delay', None)
+        pre_reboot_delay = self._task.args.get('pre_reboot_delay', None)
+        test_command = self._task.args.get('test_command', None)
+        reboot_timeout = self._task.args.get('reboot_timeout', None)
+
+        start = datetime.utcnow()
+
+        if self._connection.transport == 'local':
+            msg = 'Cannot reboot the control node. Running with local connection.'
+            return {'changed': False, 'elapsed': 0, 'rebooted': False, 'failed': True, 'msg': msg}
+
+        if task_vars is None:
+            task_vars = {}
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        if result.get('skipped', False) or result.get('failed', False):
+            return result
+
+        reboot_result = self.perform_reboot(pre_reboot_delay)
+
+        if reboot_result['rc'] != 0:
+            self._display.vvv("Reboot command has failed. System still running")
+            result['failed'] = True
+            result['rebooted'] = False
+            result['msg'] = "Reboot command failed. Error was {stdout}, {stderr}".format(stdout=reboot_result['stdout'], stderr=reboot_result['stderr'])
+            elapsed = datetime.utcnow() - start
+            result['elapsed'] = str(elapsed.seconds) + ' sec'
+            return result
+
+        if post_reboot_delay is not None:
+            self._display.vvv("waiting an additional time of {delay} seconds".format(delay=post_reboot_delay))
+            time.sleep(post_reboot_delay)
+
+        result = self.validate_reboot(test_command, reboot_timeout, action_kwargs=None)
+
+        elapsed = datetime.utcnow() - start
+        result['elapsed'] = str(elapsed.seconds) + ' sec'
+
+        return result

--- a/plugins/modules/aixpert.py
+++ b/plugins/modules/aixpert.py
@@ -25,7 +25,7 @@ version_added: '2.9'
 requirements:
 - AIX
 - Python >= 2.7
-- Should be run as 'root' user
+- 'Privileged user with authorization: B(aix.security.aixpert)'
 options:
   mode:
     description:

--- a/plugins/modules/alt_disk.py
+++ b/plugins/modules/alt_disk.py
@@ -23,6 +23,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorizations: B(aix.system.install,aix.lvm.manage.change)'
 options:
   action:
     description:

--- a/plugins/modules/backup.py
+++ b/plugins/modules/backup.py
@@ -28,6 +28,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorization: B(aix.system.install)'
 options:
   action:
     description:

--- a/plugins/modules/devices.py
+++ b/plugins/modules/devices.py
@@ -26,6 +26,8 @@ version_added: '2.9'
 requirements:
 - AIX
 - Python >= 2.7
+- 'Privileged user with authorizations:
+  B(aix.device.manage.change,aix.device.manage.remove,aix.device.config)'
 options:
   attributes:
     description:

--- a/plugins/modules/emgr.py
+++ b/plugins/modules/emgr.py
@@ -26,6 +26,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorization: B(aix.system.install)'
 options:
   action:
     description:

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -23,6 +23,8 @@ version_added: '2.9'
 requirements:
 - AIX
 - Python >= 2.7
+- 'Privileged user with authorizations:
+  B(aix.fs.manage.list,aix.fs.manage.create,aix.fs.manage.change,aix.fs.manage.remove,aix.network.nfs.mount)'
 options:
   filesystem:
     description:

--- a/plugins/modules/flrtvc.py
+++ b/plugins/modules/flrtvc.py
@@ -30,6 +30,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorizations: B(aix.fs.manage.change,aix.system.install)'
 options:
   apar:
     description:
@@ -106,6 +107,8 @@ notes:
   - The script requires ksh93 to use.
   - B(v0.8.1) is the current version of the script, depending on changes, this module might need to
     be updated.
+  - When the FLRTVC ksh script cannot execute the emgr command, it tries with B(sudo), so you can
+    try installing B(sudo) on the managed system.
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/geninstall.py
+++ b/plugins/modules/geninstall.py
@@ -24,6 +24,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorization: B(aix.system.install)'
 options:
   action:
     description:

--- a/plugins/modules/group.py
+++ b/plugins/modules/group.py
@@ -24,7 +24,9 @@ version_added: "2.9"
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
-- Root user is required.
+- 'Privileged user with authorizations:
+  B(aix.security.group.remove.admin,aix.security.group.remove.normal,
+  aix.security.group.create.admin,aix.security.group.create.normal,aix.security.group.list)'
 options:
   name:
     description: Specifies the name of the group to manage.

--- a/plugins/modules/inittab.py
+++ b/plugins/modules/inittab.py
@@ -23,7 +23,7 @@ version_added: "2.9"
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
-- Root user is required.
+- 'Privileged user with authorization: B(aix.system.config.inittab)'
 options:
     state:
         description:

--- a/plugins/modules/installp.py
+++ b/plugins/modules/installp.py
@@ -23,6 +23,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorization: B(aix.system.install)'
 options:
   action:
     description:

--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -24,7 +24,8 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
-- Root user is required.
+- 'Privileged user with authorizations:
+  B(aix.lvm.manage.extend,aix.lvm.manage.change,aix.lvm.manage.create,aix.lvm.manage.remove)'
 options:
   state:
     description:

--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -22,7 +22,9 @@ description:
 - List and reports details about defined AIX Logical Volume Manager (LVM) components such as
   Physical volumes, Logical volumes and Volume groups in Ansible facts.
 version_added: '2.9'
-requirements: [ AIX ]
+requirements:
+- AIX >= 7.1 TL3
+- Python >= 2.7
 options:
   name:
     description:

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -23,7 +23,8 @@ version_added: "2.9"
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
-- Root user is required.
+- 'Privileged user with authorizations:
+  B(aix.lvm.manage.change,aix.lvm.manage.create,aix.lvm.manage.remove)'
 options:
   state:
     description:

--- a/plugins/modules/mkfilt.py
+++ b/plugins/modules/mkfilt.py
@@ -24,7 +24,8 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
-- User with priviledged authorizations.
+- 'Privileged user with authorizations:
+  B(aix.security.network.filt,aix.security.network.stat,aix.device.manage.create)'
 options:
   action:
     description:

--- a/plugins/modules/mktcpip.py
+++ b/plugins/modules/mktcpip.py
@@ -24,6 +24,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorization: B(aix.network.config.tcpip)'
 options:
   hostname:
     description:

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -23,7 +23,8 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
-- User with priviledged authorizations.
+- 'Privileged user with authorizations:
+  B(aix.fs.manage.list,aix.fs.manage.create,aix.fs.manage.change,aix.fs.manage.remove,aix.fs.manage.mount,aix.fs.manage.unmount)'
 options:
   state:
     description:

--- a/plugins/modules/mpio.py
+++ b/plugins/modules/mpio.py
@@ -1,0 +1,179 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020- IBM, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+author:
+- AIX Development Team (@pbfinley1911)
+module: mpio
+short_description: Returns information about MultiPath I/O capable devices.
+description:
+- Returns information about MultiPath I/O capable devices.
+version_added: '2.9'
+requirements:
+- AIX >= 7.1 TL3
+- Python >= 2.7
+options:
+  device:
+    description:
+    - Specifies the logical device name of the target device whose
+      path information is to be returned.
+    type: str
+  parent:
+    description:
+    - Indicates the logical device name of the parent device whose
+      paths are to be returned.
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Gather paths to all MultiPath I/O capable devices
+  mpio:
+- name: Print the paths
+  debug:
+    var: ansible_facts.mpio.paths
+'''
+
+RETURN = r'''
+ansible_facts:
+  description:
+  - Facts to add to ansible_facts about paths to MultiPath I/O capable devices.
+  returned: always
+  type: complex
+  contains:
+    mpio:
+      description:
+      - Contains information about drivers and paths.
+      type: dict
+      elements: dict
+      contains:
+        drivers:
+          description:
+          - Maps driver name to driver supported and selected options.
+          returned: always
+          type: dict
+          elements: dict
+          contains:
+            option:
+              description:
+              - Option currently selected.
+              returned: always
+              type: str
+            options:
+              description:
+              - Supported driver options.
+              returned: always
+              type: list
+              elements: str
+          sample:
+            "drivers": {
+                "IBMFlash": {
+                    "option": "NO_OVERRIDE",
+                    "options": [
+                        "NO_OVERRIDE",
+                        "AIX_AAPCM",
+                        "AIX_non_MPIO"
+                    ]
+                }
+            }
+        paths:
+          description:
+          - Maps device name to parent devices and connections.
+          returned: always
+          type: dict
+          elements: dict
+          sample:
+            "paths": {
+                "hdisk0": {
+                    "fscsi1": {
+                        "500507680b215660,0": {
+                            "path_id": 0,
+                            "path_status": "Available",
+                            "status": "Enabled"
+                        },
+                        "500507680b215661,0": {
+                            "path_id": 1,
+                            "path_status": "Available",
+                            "status": "Enabled"
+                        }
+                    }
+                }
+            }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def gather_facts(module):
+    paths = {}
+    drivers = {}
+
+    lspath_path = module.get_bin_path('lspath', required=True)
+    cmd = [lspath_path, '-F', 'name:parent:connection:path_id:path_status:status']
+    if module.params['device']:
+        cmd += ['-l', module.params['device']]
+    if module.params['parent']:
+        cmd += ['-p', module.params['parent']]
+    ret, stdout, stderr = module.run_command(cmd)
+    for line in stdout.splitlines():
+        fields = line.split(':')
+        if len(fields) != 6:
+            continue
+        name = fields[0]
+        if name not in paths:
+            paths[name] = {}
+        parent = fields[1]
+        if parent not in paths[name]:
+            paths[name][parent] = {}
+        connection = fields[2]
+        if connection not in paths[name][parent]:
+            paths[name][parent][connection] = dict(path_id=int(fields[3]),
+                                                   path_status=fields[4])
+            if fields[5] != 'N/A':
+                paths[name][parent][connection]['status'] = fields[5]
+
+    manage_disk_drivers_path = module.get_bin_path('manage_disk_drivers')
+    if not manage_disk_drivers_path:
+        return dict(paths=paths, drivers=drivers)
+
+    cmd = [manage_disk_drivers_path, '-l']
+    ret, stdout, stderr = module.run_command(cmd)
+    for line in stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 3:
+            continue
+        if fields[0] == 'Device':
+            continue
+        driver = dict(option=fields[1])
+        options = fields[2].split(',')
+        driver['options'] = options
+        drivers[fields[0]] = driver
+
+    return dict(paths=paths, drivers=drivers)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            device=dict(type='str'),
+            parent=dict(type='str')
+        )
+    )
+
+    facts = gather_facts(module)
+
+    module.exit_json(ansible_facts=dict(mpio=facts))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/nim.py
+++ b/plugins/modules/nim.py
@@ -27,6 +27,8 @@ requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
 - User with root authority to run the nim command.
+- 'Privileged user with authorization:
+  B(aix.system.install,aix.system.nim.config.server,aix.system.nim.stat)'
 options:
   action:
     description:

--- a/plugins/modules/nim_backup.py
+++ b/plugins/modules/nim_backup.py
@@ -1280,7 +1280,7 @@ def main():
         results['msg'] = 'Empty target list, please check their NIM states and they are reacheable.'
         module.log('Warning: Empty target list: "{0}"'.format(targets))
         module.exit_json(**results)
-    results['targets'] = targets.copy()
+    results['targets'] = list(targets)
 
     for target in targets:
         results['status'][target] = ''  # first time init

--- a/plugins/modules/nim_backup.py
+++ b/plugins/modules/nim_backup.py
@@ -28,6 +28,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:
     description:

--- a/plugins/modules/nim_flrtvc.py
+++ b/plugins/modules/nim_flrtvc.py
@@ -30,6 +30,8 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorizations:
+  B(aix.fs.manage.change,aix.system.install,aix.system.nim.config.server)'
 options:
   targets:
     description:

--- a/plugins/modules/nim_flrtvc.py
+++ b/plugins/modules/nim_flrtvc.py
@@ -382,6 +382,36 @@ def compute_c_rsh_rc(machine, rc, stdout):
     return rc, stdout
 
 
+def nim_exec(module, node, command):
+    """
+    Execute the specified command on the specified nim client using c_rsh.
+
+    return
+        - rc      return code of the command
+        - stdout  stdout of the command
+        - stderr  stderr of the command
+    """
+
+    rcmd = '( LC_ALL=C {0} ); echo rc=$?'.format(' '.join(command))
+    cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', node, rcmd]
+
+    module.debug('exec command:{0}'.format(cmd))
+
+    rc, stdout, stderr = module.run_command(cmd)
+    if rc != 0:
+        return (rc, stdout, stderr)
+
+    s = re.search(r'rc=([-\d]+)$', stdout)
+    if s:
+        rc = int(s.group(1))
+        # remove the rc of c_rsh with echo $?
+        stdout = re.sub(r'rc=[-\d]+\n$', '', stdout)
+
+    module.debug('exec command rc:{0}, output:{1}, stderr:{2}'.format(rc, stdout, stderr))
+
+    return (rc, stdout, stderr)
+
+
 def increase_fs(module, output, dest):
     """
     Increase filesystem by 100Mb
@@ -813,18 +843,17 @@ def run_lslpp(module, output, machine, filename):
         machine  (str): The remote machine name
         filename (str): The filename to store output
     """
-    if 'master' in machine:
-        cmd = ['/bin/lslpp', '-Lcq']
+    cmd = ['/bin/lslpp', '-Lcq']
+
+    if machine == 'master':
+        rc, stdout, stderr = module.run_command(cmd)
     else:
-        cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', machine,
-               '"/bin/lslpp -Lcq; echo rc=$?"']
-    rc, stdout, stderr = module.run_command(cmd)
+        rc, stdout, stderr = nim_exec(module, machine, cmd)
+
     if rc == 0:
-        rc, stdout = compute_c_rsh_rc(machine, rc, stdout)
-        if rc == 0:
-            with open(filename, 'w') as myfile:
-                myfile.write(stdout)
-            return rc
+        with open(filename, 'w') as myfile:
+            myfile.write(stdout)
+        return rc
 
     msg = 'Failed to list fileset'
     module.log(msg)
@@ -910,18 +939,17 @@ def run_emgr(module, output, machine, f_efix):
         False otherwise
     """
     # list efix information
-    if 'master' in machine:
-        cmd = ['/usr/sbin/emgr', '-lv3']
+    cmd = ['/usr/sbin/emgr', '-lv3']
+
+    if machine == 'master':
+        rc, stdout, stderr = module.run_command(cmd)
     else:
-        cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', machine,
-               '"/usr/sbin/emgr -lv3; echo rc=$?"']
-    rc, stdout, stderr = module.run_command(cmd)
+        rc, stdout, stderr = nim_exec(module, machine, cmd)
+
     if rc == 0:
-        rc, stdout = compute_c_rsh_rc(machine, rc, stdout)
-        if rc == 0:
-            with open(f_efix, 'w') as myfile:
-                myfile.write(stdout)
-            return True
+        with open(f_efix, 'w') as myfile:
+            myfile.write(stdout)
+        return True
 
     msg = 'Failed to list interim fix information'
     module.log(msg)
@@ -1418,16 +1446,9 @@ def check_targets(module, output, targets, nim_clients):
             module.log('[WARNING] {0} is not ready for NIM operation'.format(machine))
             continue
 
-        cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', machine,
-               '"/usr/bin/ls /dev/null; echo rc=$?"']
-
-        rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
-        if rc != 0:
-            msg = 'Cannot check {0} connectivity with c_rsh: command \'{1}\' returned rc: {2}'.format(machine, ' '.join(cmd), rc)
-            module.log('[WARNING] ' + msg)
-            output['messages'].append(msg)
-
-        rc, stdout = compute_c_rsh_rc(machine, rc, stdout)
+        # check vios connectivity
+        cmd = ['true']
+        rc, stdout, stderr = nim_exec(module, machine, cmd)
         if rc != 0:
             msg = 'Cannot reach {0} with c_rsh, rc:{1}, stderr:{2}'.format(machine, rc, stderr)
             module.log('[WARNING] ' + msg)

--- a/plugins/modules/nim_flrtvc.py
+++ b/plugins/modules/nim_flrtvc.py
@@ -1560,7 +1560,7 @@ def main():
         msg = 'Empty target list'
         results['meta']['messages'].append(msg)
         module.log(msg)
-    results['targets'] = targets.copy()
+    results['targets'] = list(targets)
 
     # ===========================================
     # Install flrtvc script

--- a/plugins/modules/nim_suma.py
+++ b/plugins/modules/nim_suma.py
@@ -27,6 +27,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:
     description:

--- a/plugins/modules/nim_suma.py
+++ b/plugins/modules/nim_suma.py
@@ -226,6 +226,36 @@ def max_oslevel(dic):
     return oslevel_max
 
 
+def nim_exec(module, node, command):
+    """
+    Execute the specified command on the specified nim client using c_rsh.
+
+    return
+        - rc      return code of the command
+        - stdout  stdout of the command
+        - stderr  stderr of the command
+    """
+
+    rcmd = '( LC_ALL=C {0} ); echo rc=$?'.format(' '.join(command))
+    cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', node, rcmd]
+
+    module.debug('exec command:{0}'.format(cmd))
+
+    rc, stdout, stderr = module.run_command(cmd)
+    if rc != 0:
+        return (rc, stdout, stderr)
+
+    s = re.search(r'rc=([-\d]+)$', stdout)
+    if s:
+        rc = int(s.group(1))
+        # remove the rc of c_rsh with echo $?
+        stdout = re.sub(r'rc=[-\d]+\n$', '', stdout)
+
+    module.debug('exec command rc:{0}, output:{1}, stderr:{2}'.format(rc, stdout, stderr))
+
+    return (rc, stdout, stderr)
+
+
 def run_oslevel_cmd(module, machine, oslevels):
     """
     Run the oslevel command on target machine.
@@ -239,22 +269,17 @@ def run_oslevel_cmd(module, machine, oslevels):
     """
     oslevels[machine] = 'timedout'
 
-    if machine == 'master':
-        cmd = ['/usr/bin/oslevel', '-s']
-    else:
-        cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh',
-               machine,
-               '"/usr/bin/oslevel -s; echo rc=$?"']
+    cmd = ['/usr/bin/oslevel', '-s']
 
-    rc, stdout, stderr = module.run_command(cmd)
+    if machine == 'master':
+        rc, stdout, stderr = module.run_command(cmd)
+    else:
+        rc, stdout, stderr = nim_exec(module, machine, cmd)
+
     if rc == 0:
         module.debug('{0} oslevel stdout: "{1}"'.format(machine, stdout))
         if stderr.rstrip():
             module.log('[WARNING] "{0}" command stderr: {1}'.format(' '.join(cmd), stderr))
-
-        # remove the rc of c_rsh with echo $?
-        if machine != 'master':
-            stdout = re.sub(r'rc=[-\d]+\n$', '', stdout)
 
         # return stdout only ... stripped!
         oslevels[machine] = stdout.rstrip()

--- a/plugins/modules/nim_updateios.py
+++ b/plugins/modules/nim_updateios.py
@@ -30,6 +30,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:
     description:

--- a/plugins/modules/nim_vios_alt_disk.py
+++ b/plugins/modules/nim_vios_alt_disk.py
@@ -24,6 +24,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:
     description:
@@ -278,16 +279,12 @@ def build_nim_node(module):
 
     global NIM_NODE
 
-    # =========================================================================
     # Build hmc info list
-    # =========================================================================
     nim_hmc = get_hmc_info(module)
     NIM_NODE['nim_hmc'] = nim_hmc
     module.debug('NIM HMC: {0}'.format(nim_hmc))
 
-    # =========================================================================
     # Build vios info list
-    # =========================================================================
     nim_vios = get_nim_clients_info(module, 'vios')
     NIM_NODE['nim_vios'] = nim_vios
     module.debug('NIM VIOS: {0}'.format(nim_vios))
@@ -312,9 +309,7 @@ def check_vios_targets(module, targets):
     """
     global NIM_NODE
 
-    # ===========================================
     # Check targets
-    # ===========================================
     for vios_dict in targets:
         if len(vios_dict) > 2:
             OUTPUT.append('Malformed VIOS targets {0}. Dictionary should contain 1 or 2 elements.'

--- a/plugins/modules/nim_vios_hc.py
+++ b/plugins/modules/nim_vios_hc.py
@@ -28,6 +28,7 @@ requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
 - The B(vioshc.py) script must be installed on the NIM master.
+- 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:
     description:

--- a/plugins/modules/nim_viosupgrade.py
+++ b/plugins/modules/nim_viosupgrade.py
@@ -29,6 +29,7 @@ requirements:
 - AIX >= 7.2 TL3
 - Python >= 2.7
 - ios_mksysb VIOS level >= 3.1.0.0
+- 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:
     description:

--- a/plugins/modules/reboot.py
+++ b/plugins/modules/reboot.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020- IBM, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+author:
+- AIX Development Team (@pbfinley1911)
+module: reboot
+short_description: Reboot AIX machines.
+description:
+- Reboot a machine and validate by runnning a test command once the system comes back up.
+version_added: '2.9'
+requirements:
+- Python >= 2.7
+- In ansible.cfg file, ensure that ssh_args are properly set, so that ssh connection does not end up in a hang.
+  For example, ssh_args = -o ForwardAgent=yes -o ControlPersist=30m -o ServerAliveInterval=45 -o ServerAliveCountMax=10
+options:
+  pre_reboot_delay:
+    description:
+      - Seconds to wait before reboot. Passed as a parameter to the reboot command.
+    type: int
+    default: 0
+  post_reboot_delay:
+    description:
+      - Seconds to wait for validation after reboot command was successful
+    type: int
+    default: 0
+  reboot_timeout:
+    description:
+      - Maximum seconds to wait for machine to reboot and respond to a test command.
+    type: int
+    default: 300
+  test_command:
+    description:
+      - Command to run on the rebooted host to validate system running status.
+    type: str
+    default: whoami
+'''
+
+EXAMPLES = r'''
+- name: "Reboot a machine"
+  reboot:
+    pre_reboot_delay: 20
+    post_reboot_delay: 20
+    connect_timeout: 10
+    reboot_timeout: 300
+'''
+
+RETURN = r'''
+msg:
+    description: The execution message.
+    returned: always
+    type: str
+    sample: 'System has been rebooted SUCCESSFULLY'
+rc:
+    description: The return code.
+    returned: If the command failed.
+    type: int
+stdout:
+    description: The standard output.
+    returned: If the command failed.
+    type: str
+stderr:
+    description: The standard error.
+    returned: If the command failed.
+    type: str
+'''

--- a/plugins/modules/reboot.py
+++ b/plugins/modules/reboot.py
@@ -19,6 +19,7 @@ description:
 version_added: '2.9'
 requirements:
 - Python >= 2.7
+- 'Privileged user with authorization: B(aix.system.boot.shutdown)'
 - In ansible.cfg file, ensure that ssh_args are properly set, so that ssh connection does not end up in a hang.
   For example, ssh_args = -o ForwardAgent=yes -o ControlPersist=30m -o ServerAliveInterval=45 -o ServerAliveCountMax=10
 options:

--- a/plugins/modules/suma.py
+++ b/plugins/modules/suma.py
@@ -27,6 +27,7 @@ version_added: '2.9'
 requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
+- 'Privileged user with authorizations: B(aix.system.install)'
 options:
   action:
     description:

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -25,6 +25,8 @@ requirements:
 - AIX >= 7.1 TL3
 - Python >= 2.7
 - Root user is required.
+- 'Privileged user with authorizations:
+  B(aix.security.user.remove.admin,aix.security.user.remove.normal,aix.security.user.create.admin,aix.security.user.create.normal,,aix.security.user.change,aix.security.user.list)'
 options:
   state:
     description:


### PR DESCRIPTION
This PR includes:
- reboot: new module
- mpio: new module
- use nim_exec() instead of calling c_rsh command directly in nim, nim_flrtvc, nim_suma
- Quickstart documentation: user creation with RBAC authorization
- Document required RBAC authorizations for the user in each module's requirements section
- Fix Python 2 incompatibility introduce in commit [5f6c6d1](https://github.com/IBM/ansible-power-aix/commit/5f6c6d1f9bf921279e1b77a46c2de5ebdb893d5d)
