### PR TITLE
Set min required Ansible version to 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository contains some example best practices for open source repositorie
 
 ### Ansible
 
-- Requires Ansible 2.0 or newer
+- Requires Ansible 2.9 or newer
 - For help installing Ansible, refer to the [Installing Ansible] section of the Ansible Documentation
 - For help installing the ibm.power\_aix collection, refer to the [install](docs/source/installation.rst) page of this project
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: GNU General Public License v3.0
 
-  min_ansible_version: 2.0
+  min_ansible_version: 2.9
 
   platforms:
     - name: AIX


### PR DESCRIPTION
This change should be well considered, but since the travis tests run with Ansible 2.9 it may make sense to clarify that version 2.9 or newer is preferred.