### PR TITLE
fix documenation for lvol size: parameter

### DIFF
--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -61,7 +61,7 @@ options:
     default: jfs2
   size:
     description:
-    - Specifies the size of the logical volume to create.
+    - Specifies the strip size of the striped logical volume to create.
     - Can be used to create a logical volume, hence when I(state=present).
     type: str
   extra_opts:


### PR DESCRIPTION
The documentation for the `size:` parameter of the `lvol` module incorrectly states:

    - Specifies the size of the logical volume to create.

when the parameter is actually passed to the `-S` argument of `mklv`, which uses it as the strip size for a striped logical volume. The documentation is updated to reflect reality.

Please consider changing the name of the parameter to `stripSize`, as anyone unfamiliar with the AIX commands would be surprised by the use of `size` to mean anything other than the LV size. Note that `community.general.lvol` uses `size` to mean the size of the LV.

Signed-off-by: Stephen Ulmer <ulmer@ulmer.org>

