### PR TITLE
fix to issue 72

### DIFF
--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -204,7 +204,7 @@ def create_modify_lv(module):
         if not isValid:
             result['msg'] = "Invalid logical volume %s strip_size: '%s'. %s" % (name, strip_size, reason)
             module.fail_json(**result)
-        strip_size = "-S " + strip_size 
+        strip_size = "-S " + strip_size
     else:
         strip_size = ""
 

--- a/plugins/modules/mktun.py
+++ b/plugins/modules/mktun.py
@@ -461,15 +461,15 @@ def main():
         options=dict(
             address=dict(required=True, type='str'),
             ah_algo=dict(type='str'),
-            ah_key=dict(type='str'),
+            ah_key=dict(type='str', no_log=False),
             ah_spi=dict(type='int'),
             esp_algo=dict(type='str'),
-            esp_key=dict(type='str'),
+            esp_key=dict(type='str', no_log=False),
             esp_spi=dict(type='int'),
             enc_mac_algo=dict(type='str'),
-            enc_mac_key=dict(type='str'),
+            enc_mac_key=dict(type='str', no_log=False),
             policy=dict(type='str', choices=['encr/auth', 'auth/encr', 'encr', 'auth'])
-        )
+        ),
     )
 
     ipcommon = dict(
@@ -479,7 +479,7 @@ def main():
             src=tuncommon,
             dst=tuncommon,
             tunnel_only=dict(type='bool', default=False),
-            key_lifetime=dict(type='int'),
+            key_lifetime=dict(type='int', no_log=False),
             newheader=dict(type='bool'),
             replay=dict(type='bool', default=False),
             tunnel_mode=dict(type='bool', default=True),
@@ -499,7 +499,7 @@ def main():
                     ipv6=ipcommon,
                     import_ipv4=dict(type='str'),
                     import_ipv6=dict(type='str')
-                )
+                ),
             )
         ),
     )


### PR DESCRIPTION
- Changed the option name from **size** to **strip_size**
- Update documentation to specifically say strip size
- Updated logic so that **strip_size** is no longer a required option to run the **lvol** module, it is now optional
- Closes #72 