### PR TITLE
Made changes for issue 61# according to review comments

### DIFF
--- a/plugins/modules/alt_disk.py
+++ b/plugins/modules/alt_disk.py
@@ -189,12 +189,10 @@ def get_free_pvs(module):
         if match_key and match_key.group(3) == 'None':
             hdisk = match_key.group(1)
             # Check if the disk has an _LVM signature using lquerypv
-            cmd = ['lquerypv', '-V', hdisk]
+            cmd = ['getlvodm', '-j', hdisk]
             ret, stdout, stderr = module.run_command(cmd)
-            if ret != 0:
+            if ret != 3:
                 module.log('[WARN] could not query pv {0}'.format(hdisk))
-                continue
-            if stdout.strip() != "1":
                 continue
 
             # Retrieve disk size using getconf (bootinfo -s is deprecated)

--- a/plugins/modules/alt_disk.py
+++ b/plugins/modules/alt_disk.py
@@ -188,7 +188,7 @@ def get_free_pvs(module):
         # Only match disks that have no volume groups
         if match_key and match_key.group(3) == 'None':
             hdisk = match_key.group(1)
-            # Check if the disk has an _LVM signature using lquerypv
+            # Check if the disk has VG info in ODM using getlvodm 
             cmd = ['getlvodm', '-j', hdisk]
             ret, stdout, stderr = module.run_command(cmd)
             if ret != 3:


### PR DESCRIPTION
alt_disk_copy will force to create VG when the PV does not belong to any VG at ODM level. Using getlvodm instead of  lquerypvto can get a free PV even it has LV signature.