### PR TITLE
Use Ansible's internal file transfer mechanism to copy files to target when installing YUM

### DIFF
--- a/plugins/action/raw_copy.py
+++ b/plugins/action/raw_copy.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021- IBM, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#
+# This implements a raw_copy action using the Ansible internal
+# _transfer_file() function.
+#
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleAction, _AnsibleActionDone, AnsibleActionSkip
+from ansible.module_utils._text import to_native
+from ansible.plugins.action import ActionBase
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = True
+
+    def run(self, tmp=None, task_vars=None):
+        ''' copy a file to remote node '''
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        try:
+            dest = self._task.args.get('dest')
+            if self._remote_file_exists(dest):
+                raise AnsibleActionSkip("%s exists" % dest)
+
+            src = self._task.args.get('src')
+            src = self._find_needle('files', src)
+            if not self._play_context.check_mode:
+                self._transfer_file(src, dest)
+                result['changed'] = True
+
+            if self._play_context.check_mode:
+                raise _AnsibleActionDone()
+
+        except AnsibleAction as e:
+            result.update(e.result)
+        finally:
+            self._remove_tmp_path(self._connection._shell.tmpdir)
+
+        return result

--- a/plugins/modules/raw_copy.py
+++ b/plugins/modules/raw_copy.py
@@ -18,8 +18,11 @@ author:
 module: raw_copy
 short_description: Copy a file to a target without Python installed.
 description:
-- Uses Ansible internal hooks to copy a file to the remote host without requiring that Python be installed on the target. Useful during the bootstrapping of Python.
-- Because it uses Ansible's internals, it honors Ansible configuration and host variables like C(ansible_password) and C(ansible_host).
+- Uses Ansible internal hooks to copy a file to the remote host
+  without requiring that Python be installed on the target.  Useful
+  during the bootstrapping of Python.
+- Because it uses Ansible's internals, it honors Ansible configuration
+  and host variables like C(ansible_password) and C(ansible_host).
 - Always use ansible.builtin.copy instead of this plugin!
 version_added: '2.9'
 requirements:

--- a/plugins/modules/raw_copy.py
+++ b/plugins/modules/raw_copy.py
@@ -47,6 +47,3 @@ EXAMPLES = r'''
     src: "{{ download_dir }}/{{ yum_src }}"
     dest: "{{ target_dir }}/{{ yum_src }}"
 '''
-
-RETURN = r'''
-'''

--- a/plugins/modules/raw_copy.py
+++ b/plugins/modules/raw_copy.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021- IBM, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+author:
+- AIX Development Team (@pbfinley1911)
+module: raw_copy
+short_description: Copy a file to a target without Python installed.
+description:
+- Uses Ansible internal hooks to copy a file to the remote host without requiring that Python be installed on the target. Useful during the bootstrapping of Python.
+- Because it uses Ansible's internals, it honors Ansible configuration and host variables like C(ansible_password) and C(ansible_host).
+- Always use ansible.builtin.copy instead of this plugin!
+version_added: '2.9'
+requirements:
+- Python >= 2.7
+options:
+  src:
+    description:
+    - The name of the file to copy.
+    - If no absolute or relative path is specified, the plugin looks in C(files).
+    type: str
+    required: true
+  dest:
+    description:
+    - The absolute path, including the file name, on the remote system into which to copy the file.
+    type: str
+    required: true
+'''
+
+EXAMPLES = r'''
+- name: Transfer install images
+  ibm.power_aix.raw_copy:
+    src: "{{ download_dir }}/{{ yum_src }}"
+    dest: "{{ target_dir }}/{{ yum_src }}"
+'''
+
+RETURN = r'''
+'''

--- a/roles/power_aix_bootstrap/tasks/yum_install.yml
+++ b/roles/power_aix_bootstrap/tasks/yum_install.yml
@@ -77,16 +77,20 @@
 
 # TRANSFER files to target inventory
   - name: Transfer install images
-    raw: "scp -p {{ download_dir }}/yum_installer.sh {{ download_dir }}/{{ rpm_src }} {{ download_dir }}/{{ yum_src }} root@{{ inventory_hostname }}:{{ target_dir }}"
-    register: scp_result
-    ignore_errors: True
-    delegate_to: localhost
+    ibm.power_aix.raw_copy:
+      src: "{{ download_dir }}/{{ item }}"
+      dest: "{{ target_dir }}/{{ item }}"
+    with_items:
+      - "{{ rpm_src }}"
+      - "{{ yum_src }}"
+      - "yum_installer.sh"
+    register: copy_result
 
 # EXECUTE restore on target inventory
   - name: Restore yum bundle content
     raw: "{{ target_dir }}/yum_installer.sh {{ target_dir }}"
     ignore_errors: True
-    when: scp_result.rc == 0
+    when: copy_result.changed
 
 # REMOVE temporary filesystem resource
   - name: Remove temporary storage space


### PR DESCRIPTION
Ansible has no playbook-visible means to copy a file from the controller to the target without having Python on the target.

This leads to the *very* frustrating circumstance that playbook (and role) authors must use a locally-delegated "command:" equivalent to  launch something like scp to copy files. This fails when Ansible needs to depend on *ansible_password*, *ansible_host*, or other configuration variables that modify the controller->host connection. It is untenable to try and implement all of those possibilities in task itself.

This patch implements an action plugin as a wrapper around Ansible's internal _transfer_file(), and modifies power_aix_bootstrap to use it. The plugin is named *raw_copy* as it is does "down and dirty" operations like the *raw*module.

I tried mightily to add the plugin at the role level, with the idea that it would localize the change and prevent the plugin from being used outside of the role, but utterly failed. I don't know if roles inside collections are just not allowed to have plugins, or if I just never got the internal-to-the-role location correct.

This is my first action plugin, and I'm willing to make changes if necessary, so please don't hesitate to send feedback.