### PR TITLE
Fix to issue100: lvol module allows modification of LV copies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,21 @@ help:
 	@echo ""
 	@echo "target:"
 	@echo "clean					clean junk files"
+	@echo "lint					lint module"         
 	@echo "install-unit-test-requirements 		install python modules needed run unit testing"
 	@echo "unit-test 				run unit test suite for the collection"
+
+.PHONY: lint
+lint:
+ifdef MODULE
+	flake8 $(MODULE) --max-line-length=160 --ignore=E402,W503
+	python -m pycodestyle --max-line-length=160 --ignore=E402,W503 $(MODULE)
+	ansible-test sanity --test pep8 "$(MODULE)"
+else
+	flake8 plugins/modules/* --max-line-length=160 --ignore=E402,W503
+	python -m pycodestyle --max-line-length=160 --ignore=E402,W503 plugins/modules/*
+	ansible-test sanity --test pep8 "plugins/modules/*"
+endif
 
 .PHONY: install-unit-test-requirements
 install-unit-test-requirements:

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -172,10 +172,10 @@ import re
 
 result = None
 
+
 ####################################################################################
 # Action Handler Functions
 ####################################################################################
-
 def create_lv(module, name):
     """
     Creates a logical volume with the attributes provided in the
@@ -202,7 +202,7 @@ def create_lv(module, name):
     # -x maxumum, -Y prefix, -U userid, -G groupid, -P modes
     # -p copyn=mirrorpool, -O y/n, -k y/n
     extra_opts = module.params['extra_opts']
-   
+
     if strip_size is not None:
         isValid, reason = isSizeValid(module)
         if not isValid:
@@ -226,7 +226,7 @@ def create_lv(module, name):
         pv_list = ' '.join(module.params['pv_list'])
     else:
         pv_list = ''
-   
+
     cmd = "mklv %s %s %s %s %s" % \
         (opts, extra_opts, vg, num_log_part, pv_list)
     success_msg = "Logical volume %s created." % name
@@ -252,8 +252,8 @@ def modify_lv(module, name):
     copies = module.params['copies']
     policy = module.params['policy']
     lv_type = module.params['lv_type']
-    # -a position, -b badblocks, -d schedule, -R preferredRead, 
-    # -L label, -o y/n, -p permission, -r relocate, -s strict, 
+    # -a position, -b badblocks, -d schedule, -R preferredRead,
+    # -L label, -o y/n, -p permission, -r relocate, -s strict,
     # -u upperbound, -v verify, -w mirrorwriteconsistency, -x maxumum
     # -T O/F, -U userid, -G groupid, -P modes, -m copyn=mirrorpool
     # -M copyn, -O y/n
@@ -276,7 +276,7 @@ def modify_lv(module, name):
     fail_msg = "Failed to modify logical volume %s. Command '%s' failed." % (name, cmd)
     lv_run_cmd(module, cmd, success_msg, fail_msg, init_props)
 
-    old_num_copies = re.search("^COPIES:\s*(?P<num_copy>\d)", init_props, re.MULTILINE)
+    old_num_copies = re.search(r"^COPIES:\s*(?P<num_copy>\d)", init_props, re.MULTILINE)
     old_num_copies = int(old_num_copies.group('num_copy').strip())
     if copies != old_num_copies:
         if copies < old_num_copies:
@@ -296,7 +296,7 @@ def modify_lv(module, name):
 
     if result['msg'] == '':
         result['msg'] = "No changes were needed on logical volume %s." % name
-        
+
 
 def remove_lv(module):
     """
@@ -403,7 +403,7 @@ def lv_run_cmd(module, cmd, success_msg, fail_msg, init_props):
         if (init_props is None) or (init_props != get_lv_props(module)):
             result['msg'] += success_msg
             result['changed'] = True
-   
+
 
 def lv_exists(module):
     """

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -77,7 +77,8 @@ options:
     default: 1
   num_of_logical_partitions:
     description:
-    - Specifies the number of logical partitions
+    - Specifies the number of logical partitions or the size of the
+      the logical volume in terms of K, M, or G.
     - Can be used to create a logical volume, hence when I(state=present).
     type: int
     default: 1
@@ -284,7 +285,7 @@ def modify_lv(module, name):
         elif copies > old_num_copies:
             cmd = "mklvcopy -e %s %s %s" % (lv_policy, name, copies)
         success_msg = "\nLogical volume %s's number of copies is modified." % name
-        fail_msg = "\nFailed to modify logical volume %s. Command '%s' failed." % (name, cmd)
+        fail_msg = "\nFailed to modify the number of copies of logical volume %s." % (name)
         lv_run_cmd(module, cmd, success_msg, fail_msg, None)
 
     if new_name:
@@ -298,7 +299,7 @@ def modify_lv(module, name):
         result['msg'] = "No changes were needed on logical volume %s." % name
 
 
-def remove_lv(module):
+def remove_lv(module, name):
     """
     Remove the logical volume without confirmation.
     arguments:
@@ -309,7 +310,6 @@ def remove_lv(module):
         none
     """
     global result
-    name = module.params['lv']
 
     cmd = 'rmlv -f %s' % name
     success_msg = "Logical volume %s removed." % name
@@ -467,10 +467,10 @@ def main():
             create_lv(module, name)
     else:
         if lv_exists(module):
-            remove_lv(module)
+            remove_lv(module, name)
         else:
-            result['msg'] = "Logical volume %s does not exist, there is no need \
-                remove the logical volume." % (name)
+            result['msg'] = \
+                "Logical volume %s does not exist, there is no need to remove the logical volume." % (name)
 
     module.exit_json(**result)
 

--- a/tests/unit/plugins/modules/common/sample_lslv_output1
+++ b/tests/unit/plugins/modules/common/sample_lslv_output1
@@ -1,0 +1,22 @@
+LOGICAL VOLUME:     testlv                 VOLUME GROUP:   testvg
+LV IDENTIFIER:      00f6f42a00004c0000000179c407a0bb.1 PERMISSION:     read/write
+VG STATE:           active/complete        LV STATE:       closed/syncd
+TYPE:               jfs2                   WRITE VERIFY:   off
+MAX LPs:            512                    PP SIZE:        32 megabyte(s)
+COPIES:             1                      SCHED POLICY:   parallel
+LPs:                10                     PPs:            10
+STALE PPs:          0                      BB POLICY:      relocatable
+INTER-POLICY:       maximum                RELOCATABLE:    yes
+INTRA-POLICY:       middle                 UPPER BOUND:    1024
+MOUNT POINT:        N/A                    LABEL:          None
+DEVICE UID:         0                      DEVICE GID:     0
+DEVICE PERMISSIONS: 432                                    
+MIRROR WRITE CONSISTENCY: on/ACTIVE                              
+EACH LP COPY ON A SEPARATE PV ?: yes                                    
+Serialize IO ?:     NO                                     
+INFINITE RETRY:     no                     PREFERRED READ: 0
+DEVICESUBTYPE:      DS_LVZ                                        
+COPY 1 MIRROR POOL: None                                   
+COPY 2 MIRROR POOL: None                                   
+COPY 3 MIRROR POOL: None                                   
+ENCRYPTION:         no

--- a/tests/unit/plugins/modules/common/sample_lslv_output2
+++ b/tests/unit/plugins/modules/common/sample_lslv_output2
@@ -1,0 +1,22 @@
+LOGICAL VOLUME:     testlv                 VOLUME GROUP:   testvg
+LV IDENTIFIER:      00f6f42a00004c0000000179c407a0bb.1 PERMISSION:     read/write
+VG STATE:           active/complete        LV STATE:       closed/syncd
+TYPE:               jfs2                   WRITE VERIFY:   off
+MAX LPs:            512                    PP SIZE:        32 megabyte(s)
+COPIES:             1                      SCHED POLICY:   parallel
+LPs:                10                     PPs:            10
+STALE PPs:          0                      BB POLICY:      relocatable
+INTER-POLICY:       minimum                RELOCATABLE:    yes
+INTRA-POLICY:       middle                 UPPER BOUND:    1024
+MOUNT POINT:        N/A                    LABEL:          None
+DEVICE UID:         0                      DEVICE GID:     0
+DEVICE PERMISSIONS: 432                                    
+MIRROR WRITE CONSISTENCY: on/ACTIVE                              
+EACH LP COPY ON A SEPARATE PV ?: yes                                    
+Serialize IO ?:     NO                                     
+INFINITE RETRY:     no                     PREFERRED READ: 0
+DEVICESUBTYPE:      DS_LVZ                                        
+COPY 1 MIRROR POOL: None                                   
+COPY 2 MIRROR POOL: None                                   
+COPY 3 MIRROR POOL: None                                   
+ENCRYPTION:         no

--- a/tests/unit/plugins/modules/common/utils.py
+++ b/tests/unit/plugins/modules/common/utils.py
@@ -41,3 +41,5 @@ def fail_json(*args, **kwargs):
 #########################################################################################
 rootdir = "ansible_collections.ibm.power_aix.plugins.modules."
 lsfs_output_path = os.path.dirname(os.path.abspath(__file__)) + "/sample_lsfs_output"
+lslv_output_path1 = os.path.dirname(os.path.abspath(__file__)) + "/sample_lslv_output1"
+lslv_output_path2 = os.path.dirname(os.path.abspath(__file__)) + "/sample_lslv_output2"

--- a/tests/unit/plugins/modules/test_lvol.py
+++ b/tests/unit/plugins/modules/test_lvol.py
@@ -11,11 +11,13 @@ import copy
 from ansible_collections.ibm.power_aix.plugins.modules import lvol
 
 from .common.utils import (
-    AnsibleFailJson, fail_json, rootdir
+    AnsibleExitJson, AnsibleFailJson, exit_json, fail_json,
+    rootdir, lslv_output_path1, lslv_output_path2
 )
 
 
 params = {
+    "state": "present",
     "lv": "testlv",
     "lv_new_name": None,
     "vg": "testvg",
@@ -28,98 +30,299 @@ params = {
     "pv_list": None
 }
 
+init_result = {
+    "changed": False,
+    "msg": '',
+    "cmd": '',
+    "stdout": '',
+    "stderr": ''
+}
 
-class TestCreateModifyLV(unittest.TestCase):
+
+class TestCreateLV(unittest.TestCase):
     def setUp(self):
-        global params
+        global params, init_result
+        lvol.result = init_result
+        self.name = params['lv']
         self.module = mock.Mock()
         self.module.params = params
-        rc, stdout, stderr = 0, "sample stdout", "sample stderr"
-        self.module.run_command.return_value = (rc, stdout, stderr)
         self.module.fail_json = fail_json
-        self.lv_exist_path = rootdir + "lvol.lv_exists"
+        rc, stdout, stderr = (0, "sample stdout", "sample stderr")
+        self.module.run_command.return_value = (rc, stdout, stderr)
+        # mocked functions path
+        self.is_size_valid_path = rootdir + "lvol.isSizeValid"
 
-    def _prepare_create_lv(self, fail=False):
-        # initialize global variable in lvol module
-        lvol.result = {
-            "changed": False,
-            "msg": '',
-            "cmd": '',
-            "stdout": '',
-            "stderr": ''
-        }
-
-        # compose the command that is ran in lvol module
-        self.cmd = "mklv -t %s -y %s -c %s -e %s %s %s %s %s %s" % (
-            self.module.params["lv_type"],
-            self.module.params["lv"],
-            self.module.params["copies"],
-            "x" if self.module.params["policy"] == "maximum" else "m",
-            self.module.params["extra_opts"],
-            "" if self.module.params["strip_size"] is None else
-            "-S " + self.module.params["strip_size"],
-            self.module.params["vg"],
-            self.module.params["num_of_logical_partitions"],
-            "" if self.module.params["pv_list"] is None else
-            " ".join(self.module.params["pv_list"])
-        )
-
-        if fail:
-            rc, stdout, stderr = 1, "sample stdout", "sample stderr"
-            self.module.run_command.return_value = (rc, stdout, stderr)
-
-    def _assert_result(self, result, fail=False):
-        self.module.run_command.assert_called_once_with(self.cmd)
-        self.assertEqual(result["cmd"], self.cmd)
-        self.assertEqual(result["stdout"], "sample stdout")
-        self.assertEqual(result["stderr"], "sample stderr")
-        if not fail:
-            self.assertTrue(result["changed"])
-            self.assertEqual(result["rc"], 0)
-            pattern = r"Logical volume.*created"
-        else:
-            self.assertFalse(result["changed"])
-            self.assertTrue(result["failed"])
-            self.assertEqual(result["rc"], 1)
-            pattern = r"Failed to create"
-        self.assertRegexpMatches(result["msg"], pattern)
-
-    def test_success_create_striped_lv(self):
-        self.module.params["strip_size"] = "4K"
-        self._prepare_create_lv()
-        with mock.patch(self.lv_exist_path) as mocked_lv_exists:
-            mocked_lv_exists.return_value = False
-            lvol.create_modify_lv(self.module)
-            result = copy.deepcopy(lvol.result)
-
-        self._assert_result(result)
-
-    def test_success_create_non_striped_lv(self):
-        self._prepare_create_lv()
-        with mock.patch(self.lv_exist_path) as mocked_lv_exists:
-            mocked_lv_exists.return_value = False
-            lvol.create_modify_lv(self.module)
-            result = copy.deepcopy(lvol.result)
-
-        self._assert_result(result)
-
-    def test_fail_create_striped_lv(self):
-        self.module.params["strip_size"] = "4K"
-        self._prepare_create_lv(fail=True)
-        with mock.patch(self.lv_exist_path) as mocked_lv_exists:
-            mocked_lv_exists.return_value = False
-            with self.assertRaises(AnsibleFailJson) as result:
-                lvol.create_modify_lv(self.module)
-
+    def test_invalid_strip_size_not_power_of_two(self):
+        self.module.params['strip_size'] = "5M"
+        with self.assertRaises(AnsibleFailJson) as result:
+            lvol.create_lv(self.module, self.name)
         result = result.exception.args[0]
-        self._assert_result(result, fail=True)
+        self.assertTrue(result['failed'])
+        pattern = "Must be a power of 2"
+        self.assertRegexpMatches(result['msg'], pattern)
 
-    def test_fail_create_non_striped_lv(self):
-        self._prepare_create_lv(fail=True)
-        with mock.patch(self.lv_exist_path) as mocked_lv_exists:
-            mocked_lv_exists.return_value = False
-            with self.assertRaises(AnsibleFailJson) as result:
-                lvol.create_modify_lv(self.module)
-
+    def test_invalid_strip_size_invalid_unit(self):
+        self.module.params['strip_size'] = "64G"
+        with self.assertRaises(AnsibleFailJson) as result:
+            lvol.create_lv(self.module, self.name)
         result = result.exception.args[0]
-        self._assert_result(result, fail=True)
+        self.assertTrue(result['failed'])
+        pattern = "Valid strip size unit are K and M."
+        self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_invalid_strip_size_above_upper_range(self):
+        self.module.params['strip_size'] = "129M"
+        with self.assertRaises(AnsibleFailJson) as result:
+            lvol.create_lv(self.module, self.name)
+        result = result.exception.args[0]
+        self.assertTrue(result['failed'])
+        pattern = "Must be between 4K and 128M"
+        self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_invalid_strip_size_below_lower_range(self):
+        self.module.params['strip_size'] = "3K"
+        with self.assertRaises(AnsibleFailJson) as result:
+            lvol.create_lv(self.module, self.name)
+        result = result.exception.args[0]
+        self.assertTrue(result['failed'])
+        pattern = "Must be between 4K and 128M"
+        self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_valid_strip_size(self):
+        self.module.params['strip_size'] = "64M"
+        lvol.create_lv(self.module, self.name)
+        result = copy.deepcopy(lvol.result)
+        self.assertTrue(result['changed'])
+        pattern = r"Logical volume \w*\d* created."
+        self.assertRegexpMatches(result['msg'], pattern)
+        pattern = "-S 64M"
+        self.assertRegexpMatches(result['cmd'], pattern)
+
+    def test_fail_create_lv(self):
+        rc, stdout, stderr = (1, "sample stdout", "sample stderr")
+        self.module.run_command.return_value = (rc, stdout, stderr)
+        with self.assertRaises(AnsibleFailJson) as result:
+            lvol.create_lv(self.module, self.name)
+        result = result.exception.args[0]
+        self.assertTrue(result['failed'])
+        pattern = "Failed to create logical volume"
+        self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_success_create_lv(self):
+        lvol.create_lv(self.module, self.name)
+        result = copy.deepcopy(lvol.result)
+        self.assertTrue(result['changed'])
+        pattern = r"Logical volume \w*\d* created."
+        self.assertRegexpMatches(result['msg'], pattern)
+
+
+class TestModifyLV(unittest.TestCase):
+    def setUp(self):
+        global params, init_result
+        lvol.result = init_result
+        self.name = params['lv']
+        self.module = mock.Mock()
+        self.module.params = params
+        self.module.fail_json = fail_json
+        rc, stdout, stderr = (0, "sample stdout", "sample stderr")
+        self.module.run_command.return_value = (rc, stdout, stderr)
+        # mocked functions path
+        self.get_lv_props_path = rootdir + "lvol.get_lv_props"
+        # load sample output
+        with open(lslv_output_path1, "r") as f:
+            self.lslv_output1 = f.read().strip()
+        with open(lslv_output_path2, "r") as f:
+            self.lslv_output2 = f.read().strip()
+
+    def test_all_lv_props_no_change(self):
+        with mock.patch(self.get_lv_props_path) as mocked_get_lv_props:
+            mocked_get_lv_props.return_value = self.lslv_output1
+            lvol.modify_lv(self.module, self.name)
+            result = copy.deepcopy(lvol.result)
+        self.assertFalse(result['changed'])
+        pattern = "No changes were needed"
+        self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_fail_modify_lv(self):
+        rc, stdout, stderr = (1, "sample stdout", "sample stderr")
+        self.module.run_command.return_value = (rc, stdout, stderr)
+        with mock.patch(self.get_lv_props_path) as mocked_get_lv_props:
+            mocked_get_lv_props.return_value = self.lslv_output1
+            with self.assertRaises(AnsibleFailJson) as result:
+                lvol.modify_lv(self.module, self.name)
+            result = result.exception.args[0]
+            self.assertTrue(result['failed'])
+            pattern = "Failed to modify logical volume"
+            self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_success_modify_lv_fail_modify_copies(self):
+        self.module.params['copies'] = 2
+        self.module.run_command.side_effect = [
+            (0, "sample stdout", "sample stderr"),
+            (1, "sample stdout", "sample stderr")
+        ]
+        with mock.patch(self.get_lv_props_path) as mocked_get_lv_props:
+            mocked_get_lv_props.side_effect = [
+                self.lslv_output1,
+                self.lslv_output2
+            ]
+            with self.assertRaises(AnsibleFailJson) as result:
+                lvol.modify_lv(self.module, self.name)
+            result = result.exception.args[0]
+            self.assertTrue(result['changed'])
+            self.assertTrue(result['failed'])
+            pattern = r"Logical volume \w*\d* modified."
+            self.assertRegexpMatches(result['msg'], pattern)
+            pattern = "Failed to modify the number of copies"
+            self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_success_modify_lv_copies_no_change(self):
+        with mock.patch(self.get_lv_props_path) as mocked_get_lv_props:
+            mocked_get_lv_props.side_effect = [
+                self.lslv_output1,
+                self.lslv_output2
+            ]
+            lvol.modify_lv(self.module, self.name)
+            result = copy.deepcopy(lvol.result)
+        self.assertTrue(result['changed'])
+        pattern = r"Logical volume \w*\d* modified."
+        self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_success_modify_lv_copies_no_change_fail_lv_rename(self):
+        self.module.params['lv_new_name'] = "newtestlv"
+        with mock.patch(self.get_lv_props_path) as mocked_get_lv_props:
+            mocked_get_lv_props.side_effect = [
+                self.lslv_output1,
+                self.lslv_output2
+            ]
+            self.module.run_command.side_effect = [
+                (0, "sample stdout", "sample stderr"),
+                (1, "sample stdout", "sample stderr")
+            ]
+            with self.assertRaises(AnsibleFailJson) as result:
+                lvol.modify_lv(self.module, self.name)
+            result = result.exception.args[0]
+            self.assertTrue(result['changed'])
+            self.assertTrue(result['failed'])
+            pattern = r"Logical volume \w*\d* modified."
+            self.assertRegexpMatches(result['msg'], pattern)
+            pattern = "Failed to rename"
+            self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_success_modify_lv_copies_no_change_lv_renamed(self):
+        self.module.params['lv_new_name'] = "newtestlv"
+        with mock.patch(self.get_lv_props_path) as mocked_get_lv_props:
+            mocked_get_lv_props.side_effect = [
+                self.lslv_output1,
+                self.lslv_output2
+            ]
+            lvol.modify_lv(self.module, self.name)
+            result = copy.deepcopy(lvol.result)
+        pattern = r"Logical volume \w*\d* modified."
+        self.assertRegexpMatches(result['msg'], pattern)
+        pattern = "renamed into"
+        self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_success_modify_lv_copies_changed(self):
+        self.module.params['copies'] = 2
+        with mock.patch(self.get_lv_props_path) as mocked_get_lv_props:
+            mocked_get_lv_props.side_effect = [
+                self.lslv_output1,
+                self.lslv_output2
+            ]
+            lvol.modify_lv(self.module, self.name)
+            result = copy.deepcopy(lvol.result)
+        self.assertTrue(result['changed'])
+        pattern = r"Logical volume \w*\d* modified."
+        self.assertRegexpMatches(result['msg'], pattern)
+        pattern = "number of copies is modified."
+        self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_success_modify_lv_copies_changed_fail_lv_rename(self):
+        self.module.params['copies'] = 2
+        self.module.params['lv_new_name'] = "newtestlv"
+        with mock.patch(self.get_lv_props_path) as mocked_get_lv_props:
+            mocked_get_lv_props.side_effect = [
+                self.lslv_output1,
+                self.lslv_output2
+            ]
+            self.module.run_command.side_effect = [
+                (0, "sample stdout", "sample stderr"),
+                (0, "sample stdout", "sample stderr"),
+                (1, "sample stdout", "sample stderr")
+            ]
+            with self.assertRaises(AnsibleFailJson) as result:
+                lvol.modify_lv(self.module, self.name)
+            result = result.exception.args[0]
+            self.assertTrue(result['changed'])
+            self.assertTrue(result['failed'])
+            pattern = r"Logical volume \w*\d* modified."
+            self.assertRegexpMatches(result['msg'], pattern)
+            pattern = "number of copies is modified."
+            self.assertRegexpMatches(result['msg'], pattern)
+            pattern = "Failed to rename"
+            self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_success_modify_lv_copies_changed_lv_renamed(self):
+        self.module.params['copies'] = 2
+        self.module.params['lv_new_name'] = "newtestlv"
+        with mock.patch(self.get_lv_props_path) as mocked_get_lv_props:
+            mocked_get_lv_props.side_effect = [
+                self.lslv_output1,
+                self.lslv_output2
+            ]
+            lvol.modify_lv(self.module, self.name)
+            result = copy.deepcopy(lvol.result)
+        self.assertTrue(result['changed'])
+        pattern = r"Logical volume \w*\d* modified."
+        self.assertRegexpMatches(result['msg'], pattern)
+        pattern = "number of copies is modified."
+        self.assertRegexpMatches(result['msg'], pattern)
+        pattern = "renamed into"
+        self.assertRegexpMatches(result['msg'], pattern)
+
+
+class TestRemoveLV(unittest.TestCase):
+    def setUp(self):
+        global params, init_result
+        lvol.result = init_result
+        self.name = params['lv']
+        self.module = mock.Mock()
+        self.module.params = params
+        self.module.params['state'] = "absent"
+        self.module.fail_json = fail_json
+        self.module.exit_json = exit_json
+        rc, stdout, stderr = (0, "sample stdout", "sample stderr")
+        self.module.run_command.return_value = (rc, stdout, stderr)
+        # mocked functions path
+        self.ansible_module_path = rootdir + "lvol.AnsibleModule"
+        self.lv_exists_path = rootdir + "lvol.lv_exists"
+
+    def test_fail_remove_lv(self):
+        rc, stdout, stderr = (1, "sample stdout", "sample stderr")
+        self.module.run_command.return_value = (rc, stdout, stderr)
+        with self.assertRaises(AnsibleFailJson) as result:
+            lvol.remove_lv(self.module, self.name)
+        result = result.exception.args[0]
+        self.assertTrue(result['failed'])
+        pattern = "Failed to remove the logical volume"
+        self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_no_change_remove_lv(self):
+        with mock.patch(self.ansible_module_path) as mocked_ansible_module, \
+                mock.patch(self.lv_exists_path) as mocked_lv_exists:
+            mocked_ansible_module.return_value = self.module
+            mocked_lv_exists.return_value = False
+            with self.assertRaises(AnsibleExitJson) as result:
+                lvol.main()
+            result = result.exception.args[0]
+            self.assertFalse(result['changed'])
+            pattern = "there is no need to remove the logical volume"
+            self.assertRegexpMatches(result['msg'], pattern)
+
+    def test_success_remove_lv(self):
+        lvol.remove_lv(self.module, self.name)
+        result = copy.deepcopy(lvol.result)
+        self.assertTrue(result['changed'])
+        pattern = r"Logical volume \w*\d* removed"
+        self.assertRegexpMatches(result['msg'], pattern)


### PR DESCRIPTION
- allows the modification of the number of copies of a logical volume 
in the lvol module
- refactored lvol module and made it idempotent
- simplified existing test cases and added new ones for the lvol module
- added new target in Makefile called lint. this is only used when developing on you local repo to check if the coding style passes the pep8 standards. the modules flake8 and pycodestyle are required to run this target
- fixes issue #100