### PR TITLE
feature: lvol module allows extending of LV

### DIFF
--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -75,7 +75,7 @@ options:
     - Can be used to create a logical volume, hence when I(state=present).
     type: int
     default: 1
-  num_of_logical_partitions:
+  size:
     description:
     - Specifies the number of logical partitions or the size of the
       the logical volume in terms of K, M, or G.
@@ -118,24 +118,24 @@ EXAMPLES = r'''
   ibm.power_aix.lvol:
     vg: test1vg
     lv: test1lv
-    num_of_logical_parititions: 64M
+    size: 64M
 - name: Create a logical volume of 10 partitions with disks testdisk1 and testdisk2
   ibm.power_aix.lvol:
     vg: test2vg
     lv: test2lv
-    num_of_logical_parititions: 10
+    size: 10
     pv_list: [ testdisk1, testdisk2 ]
 - name: Create a logical volume of 32M with a minimum placement policy
   ibm.power_aix.lvol:
     vg: rootvg
     lv: test4lv
-    num_of_logical_parititions: 32M
+    size: 32M
     policy: minimum
 - name: Create a logical volume with extra options like mirror pool
   ibm.power_aix.lvol:
     vg: testvg
     lv: testlv
-    num_of_logical_parititions: 128M
+    size: 128M
     extra_opts: -p copy1=poolA -p copy2=poolB
 - name: Remove the logical volume
   ibm.power_aix.lvol:
@@ -196,7 +196,7 @@ def create_lv(module, name):
     copies = module.params['copies']
     policy = module.params['policy']
     vg = module.params['vg']
-    num_log_part = module.params['num_of_logical_partitions']
+    num_log_part = module.params['size']
     # -a position, -b badblocks, -C stripewidth, -d schedule
     # -R preferredRead, -L label, -m mapfile, -o y/n, -r relocate
     # -s strict, -T O, -u upperbound, -v verify, -w mirrorwriteconsistency
@@ -438,7 +438,7 @@ def main():
             strip_size=dict(type='str'),
             extra_opts=dict(type='str', default=''),
             copies=dict(type='int', default=1),
-            num_of_logical_partitions=dict(type='str', default='1'),
+            size=dict(type='str', default='1'),
             pv_list=dict(type='list', elements='str'),
             policy=dict(type='str', default='maximum', choices=['maximum', 'minimum']),
             lv_new_name=dict(type='str'),

--- a/tests/unit/plugins/modules/common/sample_lquerylv_output1
+++ b/tests/unit/plugins/modules/common/sample_lquerylv_output1
@@ -1,0 +1,2 @@
+Csize:          10
+PPsize:         25

--- a/tests/unit/plugins/modules/common/utils.py
+++ b/tests/unit/plugins/modules/common/utils.py
@@ -53,3 +53,4 @@ df_output_path2 = os.path.dirname(os.path.abspath(__file__)) + "/sample_df_outpu
 lsvg_output_path1 = os.path.dirname(os.path.abspath(__file__)) + "/sample_lsvg_output1"
 lsvg_output_path2 = os.path.dirname(os.path.abspath(__file__)) + "/sample_lsvg_output2"
 lsvg_output_path3 = os.path.dirname(os.path.abspath(__file__)) + "/sample_lsvg_output3"
+lquerylv_output_path1 = os.path.dirname(os.path.abspath(__file__)) + "/sample_lquerylv_output1"

--- a/tests/unit/plugins/modules/test_lvol.py
+++ b/tests/unit/plugins/modules/test_lvol.py
@@ -24,7 +24,7 @@ params = {
     "lv_type": "jfs2",
     "strip_size": None,
     "extra_opts": None,
-    "num_of_logical_partitions": 5,
+    "size": 5,
     "copies": 1,
     "policy": "maximum",
     "pv_list": None


### PR DESCRIPTION
- add lvol module feature to allow extending the size of the logical
volume
- reducing the size of a logical volume is NOT allowed
- change modify_lv parameters to include the initial properties
of the logical volume as input. this is done so that fetching
the initial properties is only done once as both extend_lv and
modify_lv need it
- modify modify_lv unit tests for lvol module to accomodate the
change in parameter arguments of modify_lv
- add unit test cases for extend_lv of lvol module
- rename 'num_of_logical_partitions' parameter to 'size' as
requested