### PR TITLE
lvm_facts will also display deactivated/varied off volume groups

### DIFF
--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -256,6 +256,7 @@ ansible_facts:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+import re
 
 
 def load_pvs(module, name, LVM):
@@ -329,6 +330,16 @@ def load_vgs(module, name, LVM):
             rc, out, err = module.run_command(cmd)
             if rc != 0:
                 msg += "Command '%s' failed." % cmd
+                # make sure that varied off volume groups
+                # are returned.
+                # 0516-010: Volume group must be varied on; use varyonvg command.
+                pattern = r"0516-010"
+                found = re.search(pattern, err)
+                if found:
+                    data = {
+                        'vg_state': "deactivated"
+                    }
+                    LVM['VGs'][vg] = data
             else:
                 vg_state = out.splitlines()[1].split()[2].strip()
                 num_lvs = out.splitlines()[4].split()[1].strip()


### PR DESCRIPTION
BEFORE: lvm_facts will not display volume groups that are not varied on/activated on it's output

AFTER: lvm_facts WILL include the varied off/deactivated volume groups on it's output, 
HOWEVER it will only display the vg_state of that volume group which will be deactivated and no other information. 
WHY? because the volume group needs to be varied on to actually get other relevant information regarding the volume group

IF I can't get any other information from a varied off volume group 
THEN why is it that this PR will also display these volume groups?
REASON: users might be interested on volume groups that EXISTS but NOT ACTIVATED or varied on.
