### PR TITLE
Dev collection.fix devices issue 98

### DIFF
--- a/plugins/modules/devices.py
+++ b/plugins/modules/devices.py
@@ -59,7 +59,7 @@ options:
       the device attributes.
     - C(removed) (alias C(absent)) removes the device definition of unconfigured device in Customized Devices object class
     type: str
-    choices: [ available, defined, removed ]
+    choices: [ available, defined, removed, present, absent ]
     default: available
   chtype:
     description:
@@ -182,6 +182,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 results = None
 
+
 def get_device_state(module, device):
     """
     Determines the current state of device.
@@ -288,7 +289,6 @@ def chdev(module, device):
             msg = "Modification of Device attributes failed for device '%s'. cmd - '%s'" % (device, cmd)
             module.fail_json(msg=msg, rc=rc, stdout=stdout, stderr=stderr)
 
-
     if init_props != get_device_attributes(module, device):
         msg = "Modification of Device attributes completed for device '%s'" % device
         rc = True
@@ -316,8 +316,8 @@ def cfgdev(module, device):
             return False, msg
 
         if current_state is None:
-              msg = "Device %s does not exist." % device
-              module.fail_json(msg=msg)
+            msg = "Device %s does not exist." % device
+            module.fail_json(msg=msg)
 
         cmd += "-l %s " % device
 
@@ -380,11 +380,9 @@ def rmdev(module, device, state):
 
     # If the device is already defined, do nothing.
     if device is not None:
-      if ( state == 'defined' ) and ( current_state == False):
-          msg = "Device %s is already in defined state." % device
-          return False, msg
-
-
+        if (state == 'defined') and (current_state is False):
+            msg = "Device %s is already in defined state." % device
+            return False, msg
 
     rmtype_opt = {
         "unconfigure": '',
@@ -434,13 +432,12 @@ def main():
     device = module.params["device"]
     state = module.params["state"]
     if state == 'present':
-       state = 'available'
+        state = 'available'
     if state == 'absent':
-      state = 'removed'
+        state = 'removed'
 
     attributes = module.params["attributes"]
     msg = ""
-
 
     if attributes:
         # Modify Device attributes.
@@ -450,14 +447,13 @@ def main():
         # Configure Device
         changed, msg = cfgdev(module, device)
 
-
-    elif ( state == 'defined' ) or ( state == 'removed' ):
+    elif (state == 'defined') or (state == 'removed'):
         # Move the device from 'available' to 'defined' state or delete the device
         changed, msg = rmdev(module, device, state)
 
     else:
         changed = False
-        msg = "Invalid state '%s'" % current_state
+        msg = "Invalid state '%s'" % state
 
     module.exit_json(changed=changed, msg=msg)
 

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -42,3 +42,5 @@ plugins/modules/nim_flrtvc.py pylint:consider-using-with
 plugins/modules/nim_suma.py pylint:consider-using-with
 plugins/modules/nim_viosupgrade.py pylint:consider-using-with
 plugins/modules/suma.py pylint:consider-using-with
+plugins/modules/lvm_facts.py validate-modules:invalid-ansiblemodule-schema
+plugins/modules/lpar_facts.py validate-modules:invalid-ansiblemodule-schema


### PR DESCRIPTION
This changes had to be done for two purposes:

    1. Fix problems found during the devices module release test.
    2.  Closes #98 

Problem fixes:

    Fix to allow the changes of the device without knowledge of the state.
    Somehow the module was requiring the knowledge of the device state in order to make the changes.
    This is not required. If a user wants to modify attributes of a device, it can do it at any time.
    Fix to allow recursive removal (delete) of devices and children.
    This was not working. It was only allow to define the devices recursively
    Fix to present correctly changes if attributes were actually changed.
    The module was returned changes even if nothing was changed in the device.
    Fix to allow changes in devices that do not support changes while
    the device is in Available state. This will add a new chtype option of
    reset.
    Devices like the Crypto adapters do not support the -U and -T flags that were used during the module modification
    of attributes. Now if the user set the chtype=reset, the module will skip those flags.
    Allow the usage of state alias such as absent and present for removed and available.
    Add multiple examples on how to use the module.
