### PR TITLE
Fix user module line trying to match a pattern passing a value that may not be a string.

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -140,7 +140,7 @@ def modify_user(module):
                 load_module_opts = "-R %s " % val
             else:
                 pattern = re.compile(r'(yes|true|always|no|false|never)', re.IGNORECASE)
-                if val in [True, False] or re.match(pattern, val):
+                if val in [True, False] or re.match(pattern, str(val)):
                     val = str(val).lower()
                 opts += "%s=%s " % (attr, val)
         if load_module_opts is not None:


### PR DESCRIPTION

The fix ensures the the input value is converted to a string before trying to compare it.