### PR TITLE
quote attribute arguments passed to the mkuser/chuser command when creating or modifying a user

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -142,7 +142,7 @@ def modify_user(module):
                 pattern = re.compile(r'(yes|true|always|no|false|never)', re.IGNORECASE)
                 if val in [True, False] or re.match(pattern, str(val)):
                     val = str(val).lower()
-                opts += "%s=%s " % (attr, val)
+                opts += "%s=\"%s\" " % (attr, val)
         if load_module_opts is not None:
             opts = load_module_opts + opts
         cmd = "chuser %s %s" % (opts, module.params['name'])
@@ -188,7 +188,7 @@ def create_user(module):
             if attr == 'load_module':
                 load_module_opts = "-R %s " % val
             else:
-                opts += "%s=%s " % (attr, val)
+                opts += "%s=\"%s\" " % (attr, val)
         if load_module_opts is not None:
             opts = load_module_opts + opts
 


### PR DESCRIPTION
Added quoted quotes so the command that is actually run winds up having quotes around the attributes values.
