### PR TITLE
- fix issue 157

### DIFF
--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -434,10 +434,10 @@ def umount(module):
             elif mount_dir:
                 result['msg'] = "Filesystem/Mount point '%s' is not mounted" % mount_dir
             return
-        if mount_dir:
-            cmd += mount_dir
-        elif mount_over_dir:
+        if mount_over_dir:
             cmd += mount_over_dir
+        elif mount_dir:
+            cmd += mount_dir
 
     rc, stdout, stderr = module.run_command(cmd)
     result['cmd'] = cmd


### PR DESCRIPTION
 - scenario:
    unmounting remote FS while specifying both mount_dir
    and mount_over_dir parameter

- error:
    mount_dir is used in the unmounting command instead
    of mount_over_dir

- solution:
    make sure mount_over_dir is used if mount_dir is also
    specified

- fixes #157 