### PR TITLE
Fix usage of inventory_host variable in role to install python and yu…

### DIFF
--- a/playbooks/demo_bootstrap.yml
+++ b/playbooks/demo_bootstrap.yml
@@ -2,6 +2,7 @@
 - name: "Bootstrap Yum on AIX"
   hosts: aix
   gather_facts: no
+#  user: root
   collections:
   - ibm.power_aix
   tasks:
@@ -18,6 +19,7 @@
 - name: "Bootstrap Python on AIX"
   hosts: aix
   gather_facts: no
+#  user: root
   collections:
   - ibm.power_aix
   tasks:

--- a/roles/power_aix_bootstrap/tasks/python_install.yml
+++ b/roles/power_aix_bootstrap/tasks/python_install.yml
@@ -30,4 +30,4 @@
 
   - name: Print status
     debug:
-      msg: Bootstrap attempt of python on {{ inventory_hostname }} has completed
+      msg: Bootstrap attempt of python on {{ aix_host }} has completed

--- a/roles/power_aix_bootstrap/tasks/yum_install.yml
+++ b/roles/power_aix_bootstrap/tasks/yum_install.yml
@@ -77,7 +77,7 @@
 
 # TRANSFER files to target inventory
   - name: Transfer install images
-    raw: "scp -p {{ download_dir }}/yum_installer.sh {{ download_dir }}/{{ rpm_src }} {{ download_dir }}/{{ yum_src }} root@{{ inventory_hostname }}:{{ target_dir }}"
+    raw: "scp -p {{ download_dir }}/yum_installer.sh {{ download_dir }}/{{ rpm_src }} {{ download_dir }}/{{ yum_src }} root@{{ aix_host }}:{{ target_dir }}"
     register: scp_result
     ignore_errors: True
     delegate_to: localhost
@@ -95,4 +95,4 @@
 
   - name: Print status
     debug:
-      msg: Bootstrap attempt of yum on {{ inventory_hostname }} has completed
+      msg: Bootstrap attempt of yum on {{ aix_host }} has completed

--- a/roles/power_aix_bootstrap/vars/main.yml
+++ b/roles/power_aix_bootstrap/vars/main.yml
@@ -2,3 +2,4 @@
 pkgtype: "yum"
 download_dir: "~"
 target_dir: "/tmp/.ansible.cpdir.yum"
+aix_host: "{{ hostvars[inventory_hostname].inventory_hostname }}"


### PR DESCRIPTION
…m in AIX

The inventory_host variable will not expand to target hostname.
Use: "{{ hostvars[inventory_hostname].inventory_hostname }}" to retrieve
the current target host in the role.

 Example:
inventory:
[all]
machine1
machine2

role: 
host: all

The inventory_host will be equal to "all". It will not be replaced with machine1 or machine2.

