### PR TITLE
Dev collection.power aix vioshc role

### DIFF
--- a/playbooks/demo_nim_vios_hc.yml
+++ b/playbooks/demo_nim_vios_hc.yml
@@ -2,14 +2,21 @@
 - name: "VIOS health check information"
   gather_facts: yes
   hosts: nimserver
+  collections:
+  - ibm.power_aix
   
   vars:
   #VIOSes to do health check.
     targets_v: 
-      - "vios1"
-      - "vios2"
+      - "vios1,vios2"
+      - "vios3"
      
-  tasks:  
+  tasks:
+  - name: Install the vios health assessment tool on NIM
+    import_role:
+       name: power_aix_vioshc
+ #  vars:
+ #     vioshc_opt_free_size: 1000  
   
   #gather the vios health check data    
   - name: Gather the health check information

--- a/roles/power_aix_vioshc/README.md
+++ b/roles/power_aix_vioshc/README.md
@@ -1,21 +1,33 @@
 # Ansible Role: power_aix_vioshc
-The [IBM Power Systems AIX](../../README.md) collection provides an [Ansible role](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html), referred to as `power_aix_vioshc`, which installs a Virtual I/O Server health assessment tool on a NIM master.
+The [IBM Power Systems AIX](../../README.md) collection provides an [Ansible role](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html), referred to as `power_aix_vioshc`, which installs a Virtual I/O Server health assessment tool along with its dependent tools on a NIM master.
 
 For guides and reference, see the [Docs Site](https://ibm.github.io/ansible-power-aix/roles.html).
 
 ## Requirements
 
 None.
+
+## Role Variables
+
+Available variables are listed below, along with default values:
+
+    vioshc_opt_free_size (optional, str, 500)
+
+Specifies the free space in megabytes required in the /opt folder.  
+This size is used to install dependent tools required for Virtual I/O Server health assessment tool.
+
 ## Dependencies
 
 None.
 
 ## Example Playbook
 
-    - hosts: nimmaster
+    - hosts: aix
       gather_facts: no
       include_role:
         name: power_aix_vioshc
+      vars:
+        vioshc_opt_free_size: 1000
 
 ## Copyright
-© Copyright IBM Corporation 2020
+© Copyright IBM Corporation 2021

--- a/roles/power_aix_vioshc/defaults/main.yml
+++ b/roles/power_aix_vioshc/defaults/main.yml
@@ -1,0 +1,2 @@
+# Copyright (c) IBM Corporation 2021
+vioshc_opt_free_size: 500

--- a/roles/power_aix_vioshc/meta/main.yml
+++ b/roles/power_aix_vioshc/meta/main.yml
@@ -10,9 +10,9 @@ galaxy_info:
   min_ansible_version: 2.9
 
   platforms:
-  - name: AIX
-    versions:
-    - all
+    - name: AIX
+      versions:
+        - all
 
   galaxy_tags: [aix]
   dependencies: []

--- a/roles/power_aix_vioshc/tasks/main.yml
+++ b/roles/power_aix_vioshc/tasks/main.yml
@@ -1,5 +1,14 @@
 # Copyright (c) IBM Corporation 2020
 ---
+- name: Verify the host is at least aix 7.3, to install dependent tools.
+  raw: "/usr/bin/oslevel  | /usr/bin/awk -F '.' ' { print $1 $2 }'"
+  register: output
+  changed_when: false
+
+- name: Install dependent tools for vioshc
+  include_tasks: "vioshc_dep_install.yml"
+  when: (output.stdout_lines[0] | int) >= 73
+
 - name: Install vioshc.py onto target
   copy:
     src: vioshc.py

--- a/roles/power_aix_vioshc/vars/main.yml
+++ b/roles/power_aix_vioshc/vars/main.yml
@@ -1,0 +1,3 @@
+# Copyright (c) IBM Corporation 2020
+
+vioshc_opt_free_size: 500

--- a/roles/power_aix_vioshc/vars/main.yml
+++ b/roles/power_aix_vioshc/vars/main.yml
@@ -1,3 +1,0 @@
-# Copyright (c) IBM Corporation 2020
-
-vioshc_opt_free_size: 500


### PR DESCRIPTION
1. Updates to power_aix_vioshc role to install dependencies for VIOS health assessment tool for AIX 7.3 and above.
2. The role uses power_aix_bootstrap role to install the dependencies  such as pycurl.
3. AIX versions 7.2, 7.1 with yum doesn't need to install those dependencies as they are present as part of yum prerequisites.