### PR TITLE
AIX toolsbox modifed the dnf install script. The -n option is no long…

### DIFF
--- a/roles/power_aix_bootstrap/tasks/dnf_install.yml
+++ b/roles/power_aix_bootstrap/tasks/dnf_install.yml
@@ -149,7 +149,7 @@
           - yum_exists.stdout is search("true")
 
      - name: Restore dnf bundle at the target if yum is not installed.
-       raw: "{{ target_dir }}/{{ dnf_install_script }} -n {{ target_dir }}"
+       raw: "{{ target_dir }}/{{ dnf_install_script }} -d {{ target_dir }}"
        ignore_errors: true
        when:
           - scp_result.rc == 0


### PR DESCRIPTION
…er the

action to install only dnf. The option -d should be used instead.