### PR TITLE
Display in flrtvc module a message if no interim fixes were installed…

### DIFF
--- a/playbooks/demo_suma.yml
+++ b/playbooks/demo_suma.yml
@@ -5,6 +5,8 @@
   vars:
     download_dir: /usr/sys/inst.images
     download_only: False
+#    action download will download and install the fixes.
+    action_v: list
   tasks:
 
   - name: Check oslevel of system
@@ -29,6 +31,7 @@
 
   - name: Check for, and install, system updates
     ibm.power_aix.suma:
+      action: "{{ action_v }}"
       oslevel: 'latest'
       download_dir: "{{ download_dir }}"
       download_only: "{{ download_only }}"
@@ -55,13 +58,13 @@
 #   register: output
 # - debug: var=output
 
-  - name: Wait for 10 seconds
-    pause:
-      seconds: 10
+#  - name: Wait for 10 seconds
+#    pause:
+#      seconds: 10
 
-  - name: Wait for the system to reboot
-    wait_for_connection:
-      connect_timeout: 20
-      sleep: 5
-      delay: 5
-      timeout: 600
+#  - name: Wait for the system to reboot
+#    wait_for_connection:
+#      connect_timeout: 20
+#      sleep: 5
+#      delay: 5
+#      timeout: 600

--- a/plugins/modules/flrtvc.py
+++ b/plugins/modules/flrtvc.py
@@ -947,7 +947,11 @@ def run_flrtvc(flrtvc_path, params, force):
                     module.log('stderr:{0}'.format(stderr))
                     results['meta']['messages'].append(msg)
             myfile.write(stdout)
-
+    # There is no need to continue if there are no vulnerabilities.
+    if re.search(r"No vulnerabilities", stdout):
+        results['msg'] = 'There are no vulnerabities. \nFLRTVC completed successfully'
+        module.log(results['msg'])
+        module.exit_json(**results)
     return True
 
 
@@ -1099,6 +1103,10 @@ def run_installer(epkgs, dst_path, resize_fs=True):
         Create and build results['meta']['5.install']
     """
     if not epkgs:
+        # There were fixes downloaded but not interim fixes, which are the ones
+        # the flrtvc module could install.
+        msg = 'There are no interim fixes in epkg format to be installed.'
+        results['meta']['messages'].append(msg)
         return True
 
     destpath = os.path.abspath(os.path.join(dst_path))


### PR DESCRIPTION
…. "There are no vulnerabilities."

Problem: The flrtvc module will fail if a list with no vulnerabilities is processed.

This also will display a message indicating that there are no interim fixes
in the package downloaded.
Example, if the flrtvc downloads filesets for Java updates but
this fixes do not come in the epkg format. The user can still uncompressed manually
the package and choose which version of fixes to be installed.

The message for this situation will be "There are no interim fixes in epkg format to be installed"