### PR TITLE
New release 1.4.1 with bug fixes.

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,34 @@ Releases
 ========
 
 
+Version 1.4.1
+-------------
+Notes
+  * Fix DNF bootstrap for AIX 7.3 in role power_aix_bootstrap role in supporting new AIX Linux toolbox changes.
+  * Fix DNF bootstrap in role power_aix_bootstrap to run with Ansible Tower.
+  * Fix devices module to support inet0 add/delete routes.
+  * Fix installp module idempotency issue to show changes in case of at least one successful operation.
+  * Fix flrtvc module messages if there are no interim fixes to install.
+  * Fix flrtvc module to prevent failures after downloading compressed file fixes; there are no interim fixes to install.
+  * Issue #184: Add missing file vioshc_dep_install.yml to the power_aix_vioshc role.
+  * Fix user module idempotency issue by comparing current values to requested changes before executing any actions.
+
+
+Availability
+  * `Automation Hub v1.4.1`_
+  * `Galaxy v1.4.1`_
+  * `GitHub v1.4.1`_
+
+.. _Automation Hub v1.4.1:
+   https://cloud.redhat.com/ansible/automation-hub/ibm/power_aix
+
+.. _Galaxy v1.4.1:
+   https://galaxy.ansible.com/download/ibm-power_aix-1.4.1.tar.gz
+
+.. _GitHub v1.4.1:
+   https://github.com/IBM/ansible-power-aix/releases/download/v1.4.0/ibm-power_aix-1.4.0.tar.gz
+
+
 Version 1.4.0
 -------------
 Notes

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@ namespace: ibm
 name: power_aix
 
 # The version of the collection.
-version: 1.4.0
+version: 1.4.1
 
 # Collection README file (relative to root path)
 readme: README.md

--- a/playbooks/demo_suma.yml
+++ b/playbooks/demo_suma.yml
@@ -7,6 +7,9 @@
     download_only: False
 #    action download will download and install the fixes.
     action_v: list
+  collections:
+    - ibm.power_aix
+
   tasks:
 
   - name: Check oslevel of system
@@ -16,17 +19,17 @@
   - debug: var=output
 
   - name: Create file system for system updates
-    aix_filesystem:
+    ibm.power_aix.filesystem:
       filesystem: "{{ download_dir }}"
-      size: 1G
+      attributes: size=1G
       state: present
       vg: rootvg
     when: ansible_distribution == 'AIX'
 
   - name: Mount the file system (if necessary)
-    aix_filesystem:
-      filesystem: "{{ download_dir }}"
-      state: mounted
+    mount:
+      state: mount
+      mount_dir: "{{ download_dir }}"
     when: ansible_distribution == 'AIX'
 
   - name: Check for, and install, system updates


### PR DESCRIPTION

Replace the aix_filesystem community module with the AIX filesystem module.
This because in latest changes from the community module, the interaction with
python2 will hit an error in the module while trying to parse information.