### PR TITLE
Dev collection.nim resource group fix

### DIFF
--- a/plugins/modules/nim_resource.py
+++ b/plugins/modules/nim_resource.py
@@ -219,7 +219,7 @@ NIM_SHOWRES = [
     'adapter_def',
 ]
 # NIM resource objects that contains filesets
-# that can be fetched through nim -o showres
+# that can be fetched through nim -o showres .
 NIM_SHOWRES_FILESETS = [
     'spot',
     'lpp_source',
@@ -308,13 +308,16 @@ def res_create(nim_cmd, module):
         updated results dictionary.
     '''
 
-    cmd = nim_cmd + ' -a server=master -o define '
     opts = ""
     name = module.params['name']
     object_type = module.params['object_type']
     attributes = module.params['attributes']
 
     if object_type:
+        if object_type == "res_group":
+            cmd = nim_cmd + ' -o define '
+        else:
+            cmd = nim_cmd + ' -a server=master -o define '
         cmd += ' -t ' + object_type
 
     if attributes is not None:
@@ -338,7 +341,8 @@ def res_create(nim_cmd, module):
     if return_code != 0:
 
         # 0042-081 The resource already exists on "master"
-        pattern = r"0042-081"
+        # 0042-032 object name must be unique
+        pattern = r"0042-081|0042-032"
         found = re.search(pattern, stderr)
         if not found:
             results['rc'] = return_code

--- a/roles/power_aix_bootstrap/tasks/yum_install.yml
+++ b/roles/power_aix_bootstrap/tasks/yum_install.yml
@@ -61,7 +61,7 @@
   register: script_dest
   delegate_to: localhost
 
-- name: Copy the installer script file
+- name: Copy the installer script file to "{{ download_dir }}"
   copy:
      src: "files/yum_installer.sh"
      dest: "{{ download_dir }}/yum_installer.sh"
@@ -70,35 +70,38 @@
   delegate_to: localhost
 
 # DEFINE / EXPAND target path
-- name: Check for target directory
+- name: Check for target directory "{{ target_dir }}"
   raw: "test -d {{ target_dir }} && echo true || echo false"
   register: target_exists
   ignore_errors: true
   changed_when: false
 
-- name: Check for target yum bundle
+- name: Check for target yum bundle "{{ target_dir }}/{{ yum_src }}"
   raw: "test -e {{ target_dir }}/{{ yum_src }} && echo true || echo false"
   register: yum_target_exists
   when: target_exists.stdout is search("true")
   ignore_errors: true
   changed_when: false
 
-- name: Create target filesystem for image transfer
+- name: Create target filesystem for image transfer " ( {{ target_dir }} )"
   raw: "crfs -v jfs2 -g rootvg -a size=200M -m {{ target_dir }} -A yes -p rw"
   register: crfs_result
   when: target_exists.stdout is search("false")
 
-- name: Mount target filesystem
+- name: Mount target filesystem "{{ target_dir }}"
   raw: "mount {{ target_dir }}"
   when: crfs_result.rc is defined and crfs_result.rc == 0
 
 # TRANSFER files to target inventory
-- name: Transfer install images  # noqa no-changed-when
-  raw: "scp -p {{ download_dir }}/yum_installer.sh {{ download_dir }}/{{ rpm_src }} {{ download_dir }}/{{ yum_src }} root@{{ aix_host }}:{{ target_dir }}"
+- name: Set transfer destination
+  set_fact:
+     destination: "{{ ansible_user }}@{{ aix_host }}:{{ target_dir }}"
+
+- name: Transfer install images to "{{ destination }}"  # noqa no-changed-when
+  raw: "scp -p {{ download_dir }}/yum_installer.sh {{ download_dir }}/{{ rpm_src }} {{ download_dir }}/{{ yum_src }} {{ destination }}"
   register: scp_result
   delegate_to: localhost
   ignore_errors: true
-
 
 # EXECUTE restore on target inventory
 - name: Restore yum bundle content


### PR DESCRIPTION
The new nim_resource module action to create a group resource type errors out.

    - name: Define a group resource
      ibm.power_aix.nim_resource:
        action: create
        name: "{{ res_group_v }}"
        object_type: res_group
        attributes:
          spot: "{{ spot_v }}"
          mksysb: "{{ mksysb_name_v }}"
          bosinst_data: "{{ bos_inst_name_v }}"
          comments: "Group resource for lpar01 with Spot and mksysb"

The problem is that the nim_resource module is adding the -a server=master which is incompatible with this type of nim object. The fix will not add this attribute if a resource type is being created. 

Second fix is to the power_aix_bootstrap role. This role is using the raw module to issue an scp to the end-node and is using always root as the user. But if the users create a different user for security, the role will still try to use root, failing in the process. 

