### PR TITLE
be more strict on mount check

### DIFF
--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -275,7 +275,7 @@ def is_fspath_mounted(module, mount_dir, mount_over_dir):
         for ln in stdout.splitlines()[1:]:
             fdirs.append(ln.split()[-1])
     for fdir in fdirs:
-        found = re.search(fs_name, fdir)
+        found = re.search('^' + fs_name + '$', fdir)
         if found:
             return True
 


### PR DESCRIPTION
The mount check is inaccurate in case we have similar named filesystems, e.g. `/opt/app1` and `/opt/app1libs`
The first matches both filesystems. This change implements a more strict check.