### PR TITLE
devops workflow failing for python-3.6 on latest ubuntu release

### DIFF
--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -16,7 +16,7 @@ jobs:
   # with python version 2.7, 3.6, 3.7, and 3.8
   ########################################################################
   compile-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ansible_collections/ibm/power_aix


### PR DESCRIPTION
trying ubuntu version 20.04

Signed-off-by: nitismis <nitismis@in.ibm.com>