### PR TITLE
Updates from Client work

### DIFF
--- a/.remote-sync.json
+++ b/.remote-sync.json
@@ -1,0 +1,11 @@
+{
+  "uploadOnSave": false,
+  "useAtomicWrites": false,
+  "deleteLocal": false,
+  "ignore": [
+    ".remote-sync.json",
+    ".git/**"
+  ],
+  "watch": [],
+  "transport": "scp"
+}

--- a/plugins/modules/internal/nim_select_target_disk.py
+++ b/plugins/modules/internal/nim_select_target_disk.py
@@ -204,6 +204,7 @@ def belong_to_vg(module, target_disk):
     # 0516-320 /usr/sbin/getlvodm: Physical volume hdisk1 is not assigned to
     #        a volume group.
     # physical volume belongs to a volume group if 'found' is not null
+    #pattern = r"0516-320"
     pattern = r"0516-320|0516-1396"
     found = re.search(pattern, stderr, re.MULTILINE)
     if rc != 0 and not found:
@@ -320,12 +321,17 @@ def check_rootvg(module):
             pp_size = int(match_key.group(1))
             continue
 
+        match_key = re.match(r"TOTAL PVs:\s+(\d+)\s+.*", line)
+        if match_key:
+            total_pvs = int(match_key.group(1))
+            continue
+
     if total_pps == -1 or used_pps == -1 or pp_size == -1:
         msg = 'Failed to get rootvg size, parsing error.\n'
         fail_handler(module, rc, cmd, stdout, stderr, msg=msg)
 
-    total_size = pp_size * total_pps
-    used_size = pp_size * used_pps
+    total_size = pp_size * total_pps / total_pvs
+    used_size = pp_size * used_pps / total_pvs
 
     vg_info["status"] = 0
     vg_info["rootvg_size"] = total_size

--- a/plugins/modules/internal/nim_select_target_disk.py
+++ b/plugins/modules/internal/nim_select_target_disk.py
@@ -204,7 +204,7 @@ def belong_to_vg(module, target_disk):
     # 0516-320 /usr/sbin/getlvodm: Physical volume hdisk1 is not assigned to
     #        a volume group.
     # physical volume belongs to a volume group if 'found' is not null
-    pattern = r"0516-320"
+    pattern = r"0516-320|0516-1396"
     found = re.search(pattern, stderr, re.MULTILINE)
     if rc != 0 and not found:
         fail_handler(module, rc, cmd, stdout, stderr)

--- a/roles/nim_alt_disk_migration/tasks/add_alt_disk_install_fileset.yml
+++ b/roles/nim_alt_disk_migration/tasks/add_alt_disk_install_fileset.yml
@@ -7,7 +7,7 @@
 - name: "Add 'bos.alt_disk_install.rte fileset to {{ spot }}"
   block:
     - command: >
-        nim -o cust -a lpp_source={{ lpp_source }}
+        nim -o cust -a lpp_source={{ nim_mast_lpp | default(lpp_source) }}
         -a filesets=bos.alt_disk_install.rte {{ spot }}
       register: spot_fileset_install
 

--- a/roles/nim_alt_disk_migration/tasks/get_oslevel.yml
+++ b/roles/nim_alt_disk_migration/tasks/get_oslevel.yml
@@ -4,7 +4,7 @@
     action: check
     targets: "{{ nim_client }}"
   register: nim_check
-- debug: var=nim_check
+- debug: var=nim_check.nim_node.standalone[nim_client]
 
 ############################################################
 # NOTE: steps on parsing

--- a/roles/nim_alt_disk_migration/tasks/main.yml
+++ b/roles/nim_alt_disk_migration/tasks/main.yml
@@ -182,6 +182,23 @@
     #############################################################
     #############################################################
 
+    - name: "Clear nimadm_options variable when CacheVG and Bundle not defined"
+      set_fact:
+        nimadm_options:  ""
+      when:
+        - nimadm_cache_vg | default("N/A")  == "N/A"
+        - nimadm_bundle   | default("N/A")  == "N/A"
+
+    - name: "Add CacheVG to 'nimadm_options' when nimadm_cache_vg configured"
+      set_fact:
+        nimadm_options: "-j {{ nimadm_cache_vg }}"
+      when: nimadm_cache_vg | default("N/A")  != "N/A"
+
+    - name: "Add eFix Bundle to 'nimadm_options' when nimadm_bundle configured"
+      set_fact:
+        nimadm_options: "{{ nimadm_options | default('') }} -b {{ nimadm_bundle }}"
+      when: nimadm_bundle | default("N/A")  != "N/A"
+
     ############################################################
     # - asynchronous action and polling
     #   large timeout: nimadm takes 2-3 hours to complete
@@ -198,9 +215,14 @@
     - name: "Execute nimadm and wait for migration completion."
       block:
 
+        - name: "Display nimadm command"
+          debug:
+            msg: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} {{ nimadm_options }} -Y -d {{ client_target_disk | quote }}"
+
         - name: "Migrate to alternate disk"  # noqa no-changed-when
           #command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -d {{ client_target_disk }} -Y"
-          command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -Y -d {{ client_target_disk | quote }}"
+          #command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -Y -d {{ client_target_disk | quote }}"
+          command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} {{ nimadm_options }} -Y -d {{ client_target_disk | quote }}"
           register: results
           async: "{{ wait_nimadm_timeout_secs }}"
           poll: 0
@@ -285,8 +307,8 @@
       - "{{ msg1 }} \n- Migration of {{ nim_client }} to {{ lpp_source_fileset_level }}
          NOT Completed"
       - "    Skipping call to nimadm due to debug_skip_nimadm (debug preview action only)"
-      - "    /usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -d
-        {{ client_target_disk }} -Y"
+      - "    /usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} {{ nimadm_options }}
+        -Y -d {{ client_target_disk | quote }} "
   when: debug_skip_nimadm and control_phases.perform_migration and not no_need_to_migrate
 
 - debug:

--- a/roles/nim_alt_disk_migration/tasks/main.yml
+++ b/roles/nim_alt_disk_migration/tasks/main.yml
@@ -184,7 +184,7 @@
 
     - name: "Clear nimadm_options variable when CacheVG and Bundle not defined"
       set_fact:
-        nimadm_options:  ""
+        nimadm_options: ""
       when:
         - nimadm_cache_vg | default("N/A")  == "N/A"
         - nimadm_bundle   | default("N/A")  == "N/A"
@@ -220,8 +220,8 @@
             msg: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} {{ nimadm_options }} -Y -d {{ client_target_disk | quote }}"
 
         - name: "Migrate to alternate disk"  # noqa no-changed-when
-          #command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -d {{ client_target_disk }} -Y"
-          #command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -Y -d {{ client_target_disk | quote }}"
+          # command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -d {{ client_target_disk }} -Y"
+          # command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -Y -d {{ client_target_disk | quote }}"
           command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} {{ nimadm_options }} -Y -d {{ client_target_disk | quote }}"
           register: results
           async: "{{ wait_nimadm_timeout_secs }}"

--- a/roles/nim_alt_disk_migration/tasks/main.yml
+++ b/roles/nim_alt_disk_migration/tasks/main.yml
@@ -199,7 +199,8 @@
       block:
 
         - name: "Migrate to alternate disk"  # noqa no-changed-when
-          command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -d {{ client_target_disk }} -Y"
+          #command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -d {{ client_target_disk }} -Y"
+          command: "/usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -Y -d {{ client_target_disk | quote }}"
           register: results
           async: "{{ wait_nimadm_timeout_secs }}"
           poll: 0
@@ -275,13 +276,13 @@
 
 - set_fact:
     msg1: >
-      " {{ msg1 }} \n- Migration of {{ nim_client_v }} to {{ lpp_source_fileset_level }}
+      " {{ msg1 }} \n- Migration of {{ nim_client }} to {{ lpp_source_fileset_level }}
       Completed."
   when: control_phases.perform_migration and not debug_skip_nimadm and not no_need_to_migrate
 
 - set_fact:
     msg1:
-      - "{{ msg1 }} \n- Migration of {{ nim_client_v }} to {{ lpp_source_fileset_level }}
+      - "{{ msg1 }} \n- Migration of {{ nim_client }} to {{ lpp_source_fileset_level }}
          NOT Completed"
       - "    Skipping call to nimadm due to debug_skip_nimadm (debug preview action only)"
       - "    /usr/sbin/nimadm -c {{ nim_client }} -l {{ lpp_source }} -s {{ spot }} -d

--- a/roles/nim_alt_disk_migration/tasks/validate_alt_disk_install_fileset.yml
+++ b/roles/nim_alt_disk_migration/tasks/validate_alt_disk_install_fileset.yml
@@ -131,8 +131,10 @@
     - fail:
         msg: >
           NIM master and {{ lpp_source }} 'bos.alt_disk_install.rte'
-          fileset levels do not match
-      when: lpp_source_fileset_level != nim_master_fileset_level
+          fileset level
+          {{ lpp_source_fileset_level }} > {{ nim_master_fileset_level }}
+          fileset levels invalid - LPP Source cannot be higher than NIM Master
+      when: lpp_source_fileset_level > nim_master_fileset_level
 
 ############################################################
 ############################################################
@@ -143,7 +145,9 @@
     - fail:
         msg: >
             NIM master and {{ spot }} 'bos.alt_disk_install.rte'
+            {{ spot_fileset_level }} not in  {{ nim_master_fileset_levels }}
             fileset levels do not match
+            Install 'bos.alt_disk_install.rte' from {{ nim_master_fileset_level }} into {{ spot }}
       when: "spot_fileset_level not in nim_master_fileset_levels"
   when: spot != ""
 
@@ -163,7 +167,8 @@
     - fail:
         msg: >
           {{ lpp_source }} and {{ spot }} 'bos.alt_disk_install.rte'
-          fileset levels do not match
+          {{ spot_fileset_level }} < {{ lpp_source_fileset_level }}
+          fileset levels are not supported - LPP Source cannot be higher than SPOT
 
-      when: spot_fileset_level != lpp_source_fileset_level
+      when: spot_fileset_level < lpp_source_fileset_level
   when: spot != ""

--- a/roles/nim_alt_disk_migration/tasks/validate_alt_disk_install_fileset.yml
+++ b/roles/nim_alt_disk_migration/tasks/validate_alt_disk_install_fileset.yml
@@ -145,7 +145,7 @@
     - fail:
         msg: >
             NIM master and {{ spot }} 'bos.alt_disk_install.rte'
-            {{ spot_fileset_level }} not in  {{ nim_master_fileset_levels }}
+            {{ spot_fileset_level }} not in {{ nim_master_fileset_levels }}
             fileset levels do not match
             Install 'bos.alt_disk_install.rte' from {{ nim_master_fileset_level }} into {{ spot }}
       when: "spot_fileset_level not in nim_master_fileset_levels"


### PR DESCRIPTION
Changes:
* Target didk without PVID accepted
* Divide Used PVs by number of PVs to overcome multiple PVs in rootvg
* Allow install of AIX level lower than NIM master AIX level
* Reduce debug info after checking client OS level
* Add cache VG and Bundle to nimadm options
* Re-order nimadm flags and "quote" disk variable to allow multiple PVs in rootvg
* Correct {{ nim_client_v }} to {{ nim_client }}

Sample of role in playbook.
```
    - include_role:
        name: power_aix/nim_alt_disk_migration
      vars:
        nim_client:      "{{ NIM_Client }}"
        target_disk:
          disk_name:     "{{ Target_DISK.disk_name }}"
          force:         "{{ NIMADM_Force }}"
        lpp_source:      "{{ Target_LPPS }}"
        spot:            "{{ Target_SPOT }}"
        nim_mast_lpp:    "{{ NIM_Mast_LPP }}"
        nimadm_cache_vg: "{{ NIMADM_VG | default('N/A') }}"
        nimadm_bundle:   "{{ Target_eFix | default('N/A') }}"
        control_phases:
          validate_nim_resources: "{{ NIM_Res_Check }}"
          perform_migration:      "{{ NIM_Migration }}"
        debug_skip_nimadm:        "{{ Skip_nimadm }}"

```