### PR TITLE
Fix devices module errors

### DIFF
--- a/plugins/modules/devices.py
+++ b/plugins/modules/devices.py
@@ -228,6 +228,9 @@ def check_idempotency(module, init_props, attributes, msg):
     for attr, val in attributes.items():
         if attr in init_props.keys() and str(init_props[attr]) == str(val):
             ignore_attributes.append(attr)
+    for attr in ignore_attributes:
+        if attr in attributes:
+            del attributes[attr]
 
     if len(attributes) == 0:
         results['msg'] = "All the provided attributes are already at required level."

--- a/plugins/modules/devices.py
+++ b/plugins/modules/devices.py
@@ -226,8 +226,7 @@ def check_idempotency(module, init_props, attributes, msg):
         init_props = str_to_dict(init_props, attributes)
 
     for attr, val in attributes.items():
-        if attr in init_props.keys() and init_props[attr] == val:
-            attributes.pop(attr)
+        if attr in init_props.keys() and str(init_props[attr]) == str(val):
             ignore_attributes.append(attr)
 
     if len(attributes) == 0:


### PR DESCRIPTION
This PR fixes two bugs in the devices module:

- In our environments we get a "RuntimeError: dictionary changed size during iteration" error
- When the input values of the attribues are integer we compare int vs str in L229, which is always false
