### PR TITLE
Fixed nim linting issue and build workflow

### DIFF
--- a/.github/workflows/compile-tests.yml
+++ b/.github/workflows/compile-tests.yml
@@ -13,7 +13,7 @@ jobs:
   ########################################################################
   # compile test
   # - makes sure that the collection has compatible syntax
-  # with python version 2.7, 3.6, 3.7, and 3.8
+  # with python version 3.6, 3.7, and 3.8
   ########################################################################
   compile-test:
     runs-on: ubuntu-20.04
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8']
         ansible-version: ['2.9']
 
     name: running compile tests with python ${{ matrix.python-version }}

--- a/plugins/modules/nim.py
+++ b/plugins/modules/nim.py
@@ -916,7 +916,6 @@ def check_alt_disk(module, alt_disk_update_name, target_list):
 
     cmd = "lspv " + alt_disk_update_name
     target_miss = []
-    
     for target in target_list:
         rc = nim_exec(module, target, cmd)
         if rc:


### PR DESCRIPTION
Fixed nim linting issue and removed python-2.7 from build workflow of Travis CI.