### PR TITLE
Parse lsvg header to get LV attribute indexes

### DIFF
--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -494,7 +494,7 @@ def load_lvs(module, name, LVM):
             else:
                 try:
                     lv_data = parse_lvs(stdout, vg, name)
-                    LVM['LVs'] = {**LVM['LVs'], **lv_data}
+                    LVM['LVs'].update(lv_data)
                 except (IndexError, AssertionError) as err:
                     warnings.append(str(err))
 

--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -270,7 +270,7 @@ def load_pvs(module, name, LVM):
         warnings (list): List of warning messages
         LVM      (dict): LVM facts
     """
-    warnings = list()
+    warnings = []
     cmd = "lspv"
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
@@ -305,7 +305,7 @@ def parse_pvs(lspv_output, pv_name):
     return:
         pv_data    (dict): Dictionary of PV data.
     """
-    pv_data = dict()
+    pv_data = {}
     try:
         first_line = lspv_output.splitlines()[0]
     except IndexError:
@@ -357,7 +357,7 @@ def load_vgs(module, name, LVM):
         warnings (list): List of warning messages
         LVM      (dict): LVM facts
     """
-    warnings = list()
+    warnings = []
     cmd = "lsvg"
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
@@ -401,7 +401,7 @@ def parse_vgs(lsvg_output, vg_name):
     return:
         vg_data    (dict): Dictionary of VG data.
     """
-    vg_data = dict()
+    vg_data = {}
     try:
         first_line = lsvg_output.splitlines()[0]
     except IndexError:
@@ -446,7 +446,7 @@ def load_lvs(module, name, LVM):
         warnings (list): List of warning messages
         LVM      (dict): LVM facts
     """
-    warnings = list()
+    warnings = []
     cmd = "lsvg"
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
@@ -482,7 +482,7 @@ def parse_lvs(lsvg_output, vg_name, lv_name):
                            values are data parse from the rest of the lsvg -l
                            columns.
     """
-    lv_data = dict()
+    lv_data = {}
     try:
         header = lsvg_output.splitlines()[1]
     except IndexError:
@@ -490,7 +490,7 @@ def parse_lvs(lsvg_output, vg_name, lv_name):
                          f"'lsvg -l {vg_name}' output. "
                          f"lsvg_output={lsvg_output}")
     headings = ['LV NAME', 'TYPE', 'LPs', 'PPs', 'PVs', 'LV STATE', 'MOUNT POINT']
-    headings_indexes = list()
+    headings_indexes = []
     for heading in headings:
         match = re.search(heading, header)
         assert match is not None, (f"Unable to parse 'lsvg -l {vg_name}' header. "
@@ -528,8 +528,8 @@ def main():
         ),
         supports_check_mode=True,
     )
-    return_values = dict()
-    warnings = list()
+    return_values = {}
+    warnings = []
     type = module.params['component']
     name = module.params['name']
     LVM = module.params['lvm']

--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -274,7 +274,8 @@ def load_pvs(module, name, LVM):
     cmd = "lspv"
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
-        warnings.append(f"Command failed. {cmd=} {rc=} {stdout=} {stderr=}")
+        warnings.append(f"Command failed. cmd={cmd} rc={rc} stdout={stdout} "
+                        f"stderr={stderr}")
     else:
         for ln in stdout.splitlines():
             fields = ln.split()
@@ -284,7 +285,8 @@ def load_pvs(module, name, LVM):
             cmd = "lspv -L %s" % pv
             rc, stdout, stderr = module.run_command(cmd)
             if rc != 0:
-                warnings.append(f"Command failed. {cmd=} {rc=} {stdout=} {stderr=}")
+                warnings.append(f"Command failed. cmd={cmd} rc={rc} "
+                                f"stdout={stdout} stderr={stderr}")
             else:
                 try:
                     LVM['PVs'][pv] = parse_pvs(stdout, pv)
@@ -308,10 +310,11 @@ def parse_pvs(lspv_output, pv_name):
         first_line = lspv_output.splitlines()[0]
     except IndexError:
         raise IndexError(f"Unable to get first line of 'lspv {pv_name}' "
-                         f"output. {lspv_output=}")
+                         f"output. lspv_output={lspv_output}")
     match = re.search('VOLUME GROUP', first_line)
     assert match is not None, (f"Unable to parse 'lspv {pv_name}' first line "
-                               f"to determine column sizes. {first_line=}")
+                               f"to determine column sizes. "
+                               f"first_line={first_line}")
     right_col_start_i = match.start()
     for line in lspv_output.splitlines():
         left_col = line[:right_col_start_i]
@@ -320,7 +323,7 @@ def parse_pvs(lspv_output, pv_name):
             # special case
             match = re.search('VG IDENTIFIER', line)
             assert match is not None, (f"Unable to parse 'lspv {pv_name}' "
-                                       f"VG IDENTIFIER line. {line=}")
+                                       f"VG IDENTIFIER line. line={line}")
             left_col = line[:match.start()]
             right_col = 'VG IDENTIFIER:' + line.split()[-1]
 
@@ -358,7 +361,8 @@ def load_vgs(module, name, LVM):
     cmd = "lsvg"
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
-        warnings.append(f"Command failed. {cmd=} {rc=} {stdout=} {stderr=}")
+        warnings.append(f"Command failed. cmd={cmd} rc={rc} stdout={stdout} "
+                        f"stderr={stderr}")
     else:
         for ln in stdout.splitlines():
             vg = ln.split()[0].strip()
@@ -367,7 +371,8 @@ def load_vgs(module, name, LVM):
             cmd = "lsvg %s" % vg
             rc, stdout, stderr = module.run_command(cmd)
             if rc != 0:
-                warnings.append(f"Command failed. {cmd=} {rc=} {stdout=} {stderr=}")
+                warnings.append(f"Command failed. cmd={cmd} rc={rc} "
+                                f"stdout={stdout} stderr={stderr}")
                 # make sure that varied off volume groups
                 # are returned.
                 # 0516-010: Volume group must be varied on; use varyonvg command.
@@ -401,10 +406,11 @@ def parse_vgs(lsvg_output, vg_name):
         first_line = lsvg_output.splitlines()[0]
     except IndexError:
         raise IndexError(f"Unable to get first line of 'lsvg {vg_name}' "
-                         f"output. {lsvg_output=}")
+                         f"output. lsvg_output={lsvg_output}")
     match = re.search('VG IDENTIFIER', first_line)
     assert match is not None, (f"Unable to parse 'lsvg {vg_name}' first line "
-                               f"to determine column sizes. {first_line=}")
+                               f"to determine column sizes. "
+                               f"first_line={first_line}")
     right_col_start_i = match.start()
     for line in lsvg_output.splitlines():
         left_col = line[:right_col_start_i]
@@ -444,14 +450,16 @@ def load_lvs(module, name, LVM):
     cmd = "lsvg"
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
-        warnings.append(f"Command failed. {cmd=} {rc=} {stdout=} {stderr=}")
+        warnings.append(f"Command failed. cmd={cmd} rc={rc} stdout={stdout} "
+                        f"stderr={stderr}")
     else:
         for line in stdout.splitlines():
             vg = line.split()[0].strip()
             cmd = "lsvg -l %s" % vg
             rc, stdout, stderr = module.run_command(cmd)
             if rc != 0:
-                warnings.append(f"Command failed. {cmd=} {rc=} {stdout=} {stderr=}")
+                warnings.append(f"Command failed. cmd={cmd} rc={rc} "
+                                f"stdout={stdout} stderr={stderr}")
             else:
                 try:
                     lv_data = parse_lvs(stdout, vg, name)
@@ -480,7 +488,7 @@ def parse_lvs(lsvg_output, vg_name, lv_name):
     except IndexError:
         raise IndexError(f"Unable to get header (second line) of "
                          f"'lsvg -l {vg_name}' output. "
-                         f"{lsvg_output=}")
+                         f"lsvg_output={lsvg_output}")
     headings = ['LV NAME', 'TYPE', 'LPs', 'PPs', 'PVs', 'LV STATE', 'MOUNT POINT']
     headings_indexes = list()
     for heading in headings:

--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -274,8 +274,11 @@ def load_pvs(module, name, LVM):
     cmd = "lspv"
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
-        warnings.append(f"Command failed. cmd={cmd} rc={rc} stdout={stdout} "
-                        f"stderr={stderr}")
+        warnings.append(
+                "Command failed. cmd={cmd} rc={rc} stdout={stdout} "
+                "stderr={stderr}"
+                .format(cmd=cmd, rc=rc, stdout=stdout, stderr=stderr)
+                )
     else:
         for ln in stdout.splitlines():
             fields = ln.split()
@@ -285,8 +288,11 @@ def load_pvs(module, name, LVM):
             cmd = "lspv -L %s" % pv
             rc, stdout, stderr = module.run_command(cmd)
             if rc != 0:
-                warnings.append(f"Command failed. cmd={cmd} rc={rc} "
-                                f"stdout={stdout} stderr={stderr}")
+                warnings.append(
+                        "Command failed. cmd={cmd} rc={rc} stdout={stdout} "
+                        "stderr={stderr}"
+                        .format(cmd=cmd, rc=rc, stdout=stdout, stderr=stderr)
+                        )
             else:
                 try:
                     LVM['PVs'][pv] = parse_pvs(stdout, pv)
@@ -309,12 +315,17 @@ def parse_pvs(lspv_output, pv_name):
     try:
         first_line = lspv_output.splitlines()[0]
     except IndexError as err:
-        raise IndexError(f"Unable to get first line of 'lspv {pv_name}' "
-                         f"output. lspv_output={lspv_output}") from err
+        raise IndexError(
+                "Unable to get first line of 'lspv {pv_name}' output. "
+                "lspv_output={lspv_output}"
+                .format(pv_name=pv_name, lspv_output=lspv_output)
+                ) from err
     match = re.search('VOLUME GROUP', first_line)
-    assert match is not None, (f"Unable to parse 'lspv {pv_name}' first line "
-                               f"to determine column sizes. "
-                               f"first_line={first_line}")
+    assert match is not None, (
+            "Unable to parse 'lspv {pv_name}' first line to determine column "
+            "sizes. first_line={first_line}"
+            .format(pv_name=pv_name, first_line=first_line)
+            )
     right_col_start_i = match.start()
     for line in lspv_output.splitlines():
         left_col = line[:right_col_start_i]
@@ -322,8 +333,11 @@ def parse_pvs(lspv_output, pv_name):
         if 'VG IDENTIFIER' in line:
             # special case
             match = re.search('VG IDENTIFIER', line)
-            assert match is not None, (f"Unable to parse 'lspv {pv_name}' "
-                                       f"VG IDENTIFIER line. line={line}")
+            assert match is not None, (
+                    "Unable to parse 'lspv {pv_name}' VG IDENTIFIER line. "
+                    "line={line}"
+                    .format(pv_name=pv_name, line=line)
+                    )
             left_col = line[:match.start()]
             right_col = 'VG IDENTIFIER:' + line.split()[-1]
 
@@ -361,8 +375,11 @@ def load_vgs(module, name, LVM):
     cmd = "lsvg"
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
-        warnings.append(f"Command failed. cmd={cmd} rc={rc} stdout={stdout} "
-                        f"stderr={stderr}")
+        warnings.append(
+                "Command failed. cmd={cmd} rc={rc} stdout={stdout} "
+                "stderr={stderr}"
+                .format(cmd=cmd, rc=rc, stdout=stdout, stderr=stderr)
+                )
     else:
         for ln in stdout.splitlines():
             vg = ln.split()[0].strip()
@@ -371,8 +388,11 @@ def load_vgs(module, name, LVM):
             cmd = "lsvg %s" % vg
             rc, stdout, stderr = module.run_command(cmd)
             if rc != 0:
-                warnings.append(f"Command failed. cmd={cmd} rc={rc} "
-                                f"stdout={stdout} stderr={stderr}")
+                warnings.append(
+                        "Command failed. cmd={cmd} rc={rc} stdout={stdout} "
+                        "stderr={stderr}"
+                        .format(cmd=cmd, rc=rc, stdout=stdout, stderr=stderr)
+                        )
                 # make sure that varied off volume groups
                 # are returned.
                 # 0516-010: Volume group must be varied on; use varyonvg command.
@@ -405,12 +425,17 @@ def parse_vgs(lsvg_output, vg_name):
     try:
         first_line = lsvg_output.splitlines()[0]
     except IndexError as err:
-        raise IndexError(f"Unable to get first line of 'lsvg {vg_name}' "
-                         f"output. lsvg_output={lsvg_output}") from err
+        raise IndexError(
+                "Unable to get first line of 'lsvg {vg_name}' output. "
+                "lsvg_output={lsvg_output}"
+                .format(vg_name=vg_name, lsvg_output=lsvg_output)
+                ) from err
     match = re.search('VG IDENTIFIER', first_line)
-    assert match is not None, (f"Unable to parse 'lsvg {vg_name}' first line "
-                               f"to determine column sizes. "
-                               f"first_line={first_line}")
+    assert match is not None, (
+            "Unable to parse 'lsvg {vg_name}' first line to determine column "
+            "sizes. first_line={first_line}"
+            .format(vg_name=vg_name, first_line=first_line)
+            )
     right_col_start_i = match.start()
     for line in lsvg_output.splitlines():
         left_col = line[:right_col_start_i]
@@ -450,16 +475,22 @@ def load_lvs(module, name, LVM):
     cmd = "lsvg"
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
-        warnings.append(f"Command failed. cmd={cmd} rc={rc} stdout={stdout} "
-                        f"stderr={stderr}")
+        warnings.append(
+                "Command failed. cmd={cmd} rc={rc} stdout={stdout} "
+                "stderr={stderr}"
+                .format(cmd=cmd, rc=rc, stdout=stdout, stderr=stderr)
+                )
     else:
         for line in stdout.splitlines():
             vg = line.split()[0].strip()
             cmd = "lsvg -l %s" % vg
             rc, stdout, stderr = module.run_command(cmd)
             if rc != 0:
-                warnings.append(f"Command failed. cmd={cmd} rc={rc} "
-                                f"stdout={stdout} stderr={stderr}")
+                warnings.append(
+                        "Command failed. cmd={cmd} rc={rc} stdout={stdout} "
+                        "stderr={stderr}"
+                        .format(cmd=cmd, rc=rc, stdout=stdout, stderr=stderr)
+                        )
             else:
                 try:
                     lv_data = parse_lvs(stdout, vg, name)
@@ -486,15 +517,20 @@ def parse_lvs(lsvg_output, vg_name, lv_name):
     try:
         header = lsvg_output.splitlines()[1]
     except IndexError as err:
-        raise IndexError(f"Unable to get header (second line) of "
-                         f"'lsvg -l {vg_name}' output. "
-                         f"lsvg_output={lsvg_output}") from err
+        raise IndexError(
+                "Unable to get header (second line) of 'lsvg -l {vg_name}' "
+                "output. lsvg_output={lsvg_output}"
+                .format(vg_name=vg_name, lsvg_output=lsvg_output)
+                ) from err
     headings = ['LV NAME', 'TYPE', 'LPs', 'PPs', 'PVs', 'LV STATE', 'MOUNT POINT']
     headings_indexes = []
     for heading in headings:
         match = re.search(heading, header)
-        assert match is not None, (f"Unable to parse 'lsvg -l {vg_name}' header. "
-                                   f"header='{header}' expected headings='{headings}'")
+        assert match is not None, (
+                "Unable to parse 'lsvg -l {vg_name}' header. "
+                "header='{header}' expected headings='{headings}'"
+                .format(vg_name=vg_name, header=header, headings=headings)
+                )
         headings_indexes.append(match.start())
 
     for ln in lsvg_output.splitlines()[2:]:

--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -308,9 +308,9 @@ def parse_pvs(lspv_output, pv_name):
     pv_data = {}
     try:
         first_line = lspv_output.splitlines()[0]
-    except IndexError:
+    except IndexError as err:
         raise IndexError(f"Unable to get first line of 'lspv {pv_name}' "
-                         f"output. lspv_output={lspv_output}")
+                         f"output. lspv_output={lspv_output}") from err
     match = re.search('VOLUME GROUP', first_line)
     assert match is not None, (f"Unable to parse 'lspv {pv_name}' first line "
                                f"to determine column sizes. "
@@ -404,9 +404,9 @@ def parse_vgs(lsvg_output, vg_name):
     vg_data = {}
     try:
         first_line = lsvg_output.splitlines()[0]
-    except IndexError:
+    except IndexError as err:
         raise IndexError(f"Unable to get first line of 'lsvg {vg_name}' "
-                         f"output. lsvg_output={lsvg_output}")
+                         f"output. lsvg_output={lsvg_output}") from err
     match = re.search('VG IDENTIFIER', first_line)
     assert match is not None, (f"Unable to parse 'lsvg {vg_name}' first line "
                                f"to determine column sizes. "
@@ -485,10 +485,10 @@ def parse_lvs(lsvg_output, vg_name, lv_name):
     lv_data = {}
     try:
         header = lsvg_output.splitlines()[1]
-    except IndexError:
+    except IndexError as err:
         raise IndexError(f"Unable to get header (second line) of "
                          f"'lsvg -l {vg_name}' output. "
-                         f"lsvg_output={lsvg_output}")
+                         f"lsvg_output={lsvg_output}") from err
     headings = ['LV NAME', 'TYPE', 'LPs', 'PPs', 'PVs', 'LV STATE', 'MOUNT POINT']
     headings_indexes = []
     for heading in headings:

--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -314,12 +314,12 @@ def parse_pvs(lspv_output, pv_name):
     pv_data = {}
     try:
         first_line = lspv_output.splitlines()[0]
-    except IndexError as err:
+    except IndexError:
         raise IndexError(
                 "Unable to get first line of 'lspv {pv_name}' output. "
                 "lspv_output={lspv_output}"
                 .format(pv_name=pv_name, lspv_output=lspv_output)
-                ) from err
+                )
     match = re.search('VOLUME GROUP', first_line)
     assert match is not None, (
             "Unable to parse 'lspv {pv_name}' first line to determine column "
@@ -424,12 +424,12 @@ def parse_vgs(lsvg_output, vg_name):
     vg_data = {}
     try:
         first_line = lsvg_output.splitlines()[0]
-    except IndexError as err:
+    except IndexError:
         raise IndexError(
                 "Unable to get first line of 'lsvg {vg_name}' output. "
                 "lsvg_output={lsvg_output}"
                 .format(vg_name=vg_name, lsvg_output=lsvg_output)
-                ) from err
+                )
     match = re.search('VG IDENTIFIER', first_line)
     assert match is not None, (
             "Unable to parse 'lsvg {vg_name}' first line to determine column "
@@ -516,12 +516,12 @@ def parse_lvs(lsvg_output, vg_name, lv_name):
     lv_data = {}
     try:
         header = lsvg_output.splitlines()[1]
-    except IndexError as err:
+    except IndexError:
         raise IndexError(
                 "Unable to get header (second line) of 'lsvg -l {vg_name}' "
                 "output. lsvg_output={lsvg_output}"
                 .format(vg_name=vg_name, lsvg_output=lsvg_output)
-                ) from err
+                )
     headings = ['LV NAME', 'TYPE', 'LPs', 'PPs', 'PVs', 'LV STATE', 'MOUNT POINT']
     headings_indexes = []
     for heading in headings:


### PR DESCRIPTION
Using .split() and assuming all attributes are populated caused
IndexError for certain vg configurations. The lsvg man page lists these
column headers so I'm assuming they're consistent. To be safe I've added
nice error messages if that header parse fails.

(hopefully) Fixes #63 