### PR TITLE
Added quotation marks to new_entry

### DIFF
--- a/plugins/modules/inittab.py
+++ b/plugins/modules/inittab.py
@@ -137,7 +137,7 @@ def modify_entry(module):
 
     cmd = 'chitab'
 
-    new_entry = name + ":" + runlevel + ":" + action + ":" + command
+    new_entry = "\'" + name + ":" + runlevel + ":" + action + ":" + command + "\'"
     cmd = cmd + " " + new_entry
 
     rc, stdout, stderr = module.run_command(cmd)
@@ -176,7 +176,7 @@ def create_entry(module):
         ident_opts = "-i " + identifier
         cmd = cmd + " " + ident_opts
 
-    new_entry = name + ":" + runlevel + ":" + action + ":" + command
+    new_entry = "\'" + name + ":" + runlevel + ":" + action + ":" + command + "\'"
     cmd = cmd + " " + new_entry
 
     rc, stdout, stderr = module.run_command(cmd)


### PR DESCRIPTION
Fix for issue https://github.com/IBM/ansible-power-aix/issues/341

Test 1: Execute binary

```yaml
changed: [aix0001] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "action": "respawn",
            "command": "/usr/sbin/uprintfd",
            "insertafter": null,
            "name": "uprintfd",
            "runlevel": "23456789",
            "state": "modify"
        }
    },
    "msg": "\nEntry for: uprintfd is changed SUCCESSFULLY in inittab file"
}

PLAY RECAP **************************************************************************************************************************************************************
aix0001 : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

┌──root@aix0001:07:45:03 /scratch/nv/ansible/aix/trunk
└─ $ grep uprintfd /etc/inittab
uprintfd:23456789:respawn:/usr/sbin/uprintfd
```

Test 2: Execute binary and redirect output

```yaml
changed: [aix0001] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "action": "respawn",
            "command": "/usr/sbin/uprintfd >/dev/console 2>&1",
            "insertafter": null,
            "name": "uprintfd",
            "runlevel": "23456789",
            "state": "modify"
        }
    },
    "msg": "\nEntry for: uprintfd is changed SUCCESSFULLY in inittab file"
}

PLAY RECAP **************************************************************************************************************************************************************
aix0001 : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

┌──root@aix0001:07:45:54 /scratch/nv/ansible/aix/trunk
└─ $ grep uprintfd /etc/inittab
uprintfd:23456789:respawn:/usr/sbin/uprintfd >/dev/console 2>&1
```

Test 3: Execute binary with PATH variable and redirect output

```yaml
changed: [aix0001] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "action": "respawn",
            "command": "/usr/sbin/uprintfd \"PATH=/opt\" >/dev/console 2>&1",
            "insertafter": null,
            "name": "uprintfd",
            "runlevel": "23456789",
            "state": "modify"
        }
    },
    "msg": "\nEntry for: uprintfd is changed SUCCESSFULLY in inittab file"
}

PLAY RECAP **************************************************************************************************************************************************************
aix0001 : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

┌──root@aix0001:07:46:29 /scratch/nv/ansible/aix/trunk
└─ $ grep uprintfd /etc/inittab
uprintfd:23456789:respawn:/usr/sbin/uprintfd "PATH=/opt" >/dev/console 2>&1
```

Test 4: Execute binary with PATH variable and redirect output incl. comment at end of line

```yaml
changed: [aix0001] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "action": "respawn",
            "command": "/usr/sbin/uprintfd \"PATH=/opt\" >/dev/console 2>&1 # comment",
            "insertafter": null,
            "name": "uprintfd",
            "runlevel": "23456789",
            "state": "modify"
        }
    },
    "msg": "\nEntry for: uprintfd is changed SUCCESSFULLY in inittab file"
}

PLAY RECAP **************************************************************************************************************************************************************
aix0001 : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

┌──root@aix0001:07:47:12 /scratch/nv/ansible/aix/trunk
└─ $ grep uprintfd /etc/inittab
uprintfd:23456789:respawn:/usr/sbin/uprintfd "PATH=/opt" >/dev/console 2>&1 # comment
```