### PR TITLE
Update nfs mount example in mount.py with nfsv4 option

### DIFF
--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -122,6 +122,7 @@ EXAMPLES = r'''
     node: ansible-test1
     mount_dir: /mnt/servnfs
     mount_over_dir: /mnt/clientnfs
+    options: "vers=4"
 
 - name: Mount all filesystems from the 'local' mount group
   ibm.power_aix.mount:


### PR DESCRIPTION
AIX tries version NFSv3 first and falls back to version NFSv2, but NFSv4 is never selected automatically. The example should show users how to mount nfsv4, because it is widely used.

Source: https://www.ibm.com/docs/en/aix/7.3?topic=m-mount-command