### PR TITLE
Updates for 'unavail_targets' undefined & nim update to alt_disk when 'alt_disk_update_name' is provided (issue #370)

### DIFF
--- a/plugins/modules/nim.py
+++ b/plugins/modules/nim.py
@@ -985,7 +985,7 @@ def nim_update(module, params):
 
     # if unavail_targets:
     #     # msg = "Following targets does not have specified alt_disk_update_name disk:" + str(unavail_targets)
-    #     msg = "Following targets specified alt_disk_update_name disk (" + alt_disk_update_name +") is not present or is assigned to another VG:" + str(unavail_targets)
+    #     msg = "Following target alt_disk_update_name disk (" + alt_disk_update_name +") not present or assigned to another VG:" + str(unavail_targets)
     #     results['msg'] = msg
     #     module.fail_json(**results)
 
@@ -1001,7 +1001,7 @@ def nim_update(module, params):
             continue
         if target in unavail_targets:
             target_list.remove(target)
-            msg = 'alt_disk_update_name disk (' + alt_disk_update_name +') not present or assigned to another VG.'
+            msg = 'alt_disk_update_name disk (' + alt_disk_update_name + ') not present or assigned to another VG.'
             results['meta'][target] = {'messages': [msg]}
             module.log('NIM - Error: ' + msg)
             results['status'][target] = 'FAILURE'

--- a/plugins/modules/nim.py
+++ b/plugins/modules/nim.py
@@ -701,7 +701,6 @@ def perform_customization(module, lpp_source, target, is_async):
     alt_disk_update_name = module.params['alt_disk_update_name']
 
     if alt_disk_update_name:
-        # cmd = "nim -o cust -a lpp_source=" + lpp_source + " -a installp_flags=-a -Y -d " + alt_disk_update_name + " "
         cmd = ['nim', '-o', 'alt_disk_install', '-a', 'source=rootvg', '-a', 'lpp_source=' + lpp_source,
                '-a', 'fixes=update_all', '-a', 'disk=' + alt_disk_update_name, '-a', 'installp_flags=\"-acNgXY\"',
                ]
@@ -925,8 +924,6 @@ def check_alt_disk(module, alt_disk_update_name, target_list):
         if all targets have specified alternate disk
     """
 
-    # cmd = "lspv " + alt_disk_update_name              # Original command
-    # cmd = ['/usr/sbin/lspv', alt_disk_update_name]    # Working version of original command
     cmd = ['/usr/sbin/lspv', '|/usr/bin/grep', '-w', alt_disk_update_name, '|/usr/bin/grep', '-E', '"None"']
 
     target_miss = []
@@ -982,12 +979,6 @@ def nim_update(module, params):
         unavail_targets = check_alt_disk(module, alt_disk_update_name, target_list)
     else:
         unavail_targets = []
-
-    # if unavail_targets:
-    #     # msg = "Following targets does not have specified alt_disk_update_name disk:" + str(unavail_targets)
-    #     msg = "Following target alt_disk_update_name disk (" + alt_disk_update_name +") not present or assigned to another VG:" + str(unavail_targets)
-    #     results['msg'] = msg
-    #     module.fail_json(**results)
 
     results['targets'] = list(target_list)
     module.debug('NIM - Target list: {0}'.format(target_list))

--- a/plugins/modules/nim.py
+++ b/plugins/modules/nim.py
@@ -701,11 +701,10 @@ def perform_customization(module, lpp_source, target, is_async):
     alt_disk_update_name = module.params['alt_disk_update_name']
 
     if alt_disk_update_name:
+        # cmd = "nim -o cust -a lpp_source=" + lpp_source + " -a installp_flags=-a -Y -d " + alt_disk_update_name + " "
         cmd = ['nim', '-o', 'alt_disk_install', '-a', 'source=rootvg', '-a', 'lpp_source=' + lpp_source,
                '-a', 'fixes=update_all', '-a', 'disk=' + alt_disk_update_name, '-a', 'installp_flags=\"-acNgXY\"', 
                ]
-        # cmd = "nim -o cust -a lpp_source=" + lpp_source + " -a installp_flags=-a -Y -d " + alt_disk_update_name + " "
-        # cmd += '-a async=yes' if is_async else '-a async=no'
     else:
         cmd = ['nim', '-o', 'cust',
                '-a', 'lpp_source=' + lpp_source,
@@ -926,8 +925,8 @@ def check_alt_disk(module, alt_disk_update_name, target_list):
         if all targets have specified alternate disk
     """
 
-    #cmd = "lspv " + alt_disk_update_name
-    #cmd = ['/usr/sbin/lspv', alt_disk_update_name]
+    # cmd = "lspv " + alt_disk_update_name              # Original command
+    # cmd = ['/usr/sbin/lspv', alt_disk_update_name]    # Working version of original command
     cmd = ['/usr/sbin/lspv', '|/usr/bin/grep', '-w', alt_disk_update_name, '|/usr/bin/grep', '-E', '"None"']
 
     target_miss = []
@@ -1915,7 +1914,6 @@ def main():
                                  'reset', 'reboot', 'maintenance', 'show', 'register_client']),
             lpp_source=dict(type='str'),
             targets=dict(type='list', elements='str'),
-            unavail_targets=dict(type='list', elements='str'),
             new_targets=dict(type='list', elements='str'),  # The elements format is <machine name>-<login id>-<password>
             asynchronous=dict(type='bool', default=False),
             device=dict(type='str'),

--- a/plugins/modules/nim.py
+++ b/plugins/modules/nim.py
@@ -703,7 +703,7 @@ def perform_customization(module, lpp_source, target, is_async):
     if alt_disk_update_name:
         # cmd = "nim -o cust -a lpp_source=" + lpp_source + " -a installp_flags=-a -Y -d " + alt_disk_update_name + " "
         cmd = ['nim', '-o', 'alt_disk_install', '-a', 'source=rootvg', '-a', 'lpp_source=' + lpp_source,
-               '-a', 'fixes=update_all', '-a', 'disk=' + alt_disk_update_name, '-a', 'installp_flags=\"-acNgXY\"', 
+               '-a', 'fixes=update_all', '-a', 'disk=' + alt_disk_update_name, '-a', 'installp_flags=\"-acNgXY\"',
                ]
     else:
         cmd = ['nim', '-o', 'cust',


### PR DESCRIPTION
Error `unavail_targets` is undefined when `alt_disk_update_name` is not passed to the nim module with the 'update' action. 
Included coding from https://github.com/IBM/ansible-power-aix/issues/370

**If `alt_disk_update_name` is passed the module gives an error as it is using an invalid test for the alt_disk on NIM client.**
`check_alt_disk` check code runs:
- `cmd = "lspv " + alt_disk_update_name`
- Command entered in an incorrect format and not passing full path
- `lspv hdisk{x}` is an invalid check as it only comes back with a zero return code if the disk is in an active volume group.
Update the check to:
- `cmd = ['/usr/sbin/lspv', '|/usr/bin/grep', '-w', alt_disk_update_name, '|/usr/bin/grep', '-E', '"None"']`

**Data returned from check is also invalid as each letter is turned into an array item.**
Updated return value with:
- ` target_miss .append(target)`

**Code would also fail for all targets if any did not pass `check_alt_disk`**
- Added new test after the VIOS check to remove a target from the list

**Code to update with target disk also invalid:**
- `cmd = "nim -o cust -a lpp_source=" + lpp_source + " -a installp_flags=-a -Y -d " + alt_disk_update_name + " "`
Replace with:
- `cmd = ['nim', '-o', 'alt_disk_install', '-a', 'source=rootvg', '-a', 'lpp_source=' + lpp_source,
       '-a', 'fixes=update_all', '-a', 'disk=' + alt_disk_update_name, '-a', 'installp_flags=\"-acNgXY\"',
       ]`