### PR TITLE
Include PVs without VG or unvaried VG on lvm_facts module

### DIFF
--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -373,15 +373,15 @@ def parse_pvs(module, lspv_output, pv_name):
     for key in pv_data.copy():
         if pv_data[key] == "???????":
             del pv_data[key]
-    if pv_data.get('TOTAL PPs') != None:
+    if pv_data.get('TOTAL PPs') is not None:
         pv_data['total_pps'] = pv_data['TOTAL PPs'].split()[0]
-    if pv_data.get('free_pps') != None:
+    if pv_data.get('free_pps') is not None:
         pv_data['free_pps'] = pv_data['FREE PPs'].split()[0]
-    if pv_data.get('pp_size') != None:
+    if pv_data.get('pp_size') is not None:
         pp_size_int = int(pv_data['pp_size'].split()[0])
-        if pv_data.get('total_pps') != None:
+        if pv_data.get('total_pps') is not None:
             pv_data['size_g'] = int(pv_data['total_pps']) * pp_size_int / 1024
-        if pv_data.get('free_pps') != None:
+        if pv_data.get('free_pps') is not None:
             pv_data['free_g'] = int(pv_data['free_pps']) * pp_size_int / 1024
     return pv_data
 

--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -307,8 +307,8 @@ def load_pvs(module, name, LVM):
                 )
                 if stderr.find('0516-320') > -1:
                     if fields[2] == "None":
-                      del LVM['PVs'][pv]["VOLUME GROUP"]
-                      del LVM['PVs'][pv]["vg"]
+                        del LVM['PVs'][pv]["VOLUME GROUP"]
+                        del LVM['PVs'][pv]["vg"]
                 elif stderr.find('0516-010') > -1:
                     try:
                         LVM['PVs'][pv] = parse_pvs(module, stdout, pv)

--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -296,7 +296,7 @@ def load_pvs(module, name, LVM):
             if len(fields) > 3:
                 LVM['PVs'][pv]["VG_STATE"] = fields[3]
                 LVM['PVs'][pv]["vg_state"] = fields[3]
-            
+
             cmd = "lspv -L %s" % pv
             rc, stdout, stderr = module.run_command(cmd)
             if rc != 0:


### PR DESCRIPTION
Include PVs without VG or unvaried VG on `lvm_facts` module

Fix for issue #279 

Signed-off-by: Aiman <syahrul.aiman@my.ibm.com>