### PR TITLE
Localpatchserver patch:

### DIFF
--- a/playbooks/demo_flrtvc_local_patch_server.yml
+++ b/playbooks/demo_flrtvc_local_patch_server.yml
@@ -14,6 +14,7 @@
     apar_csv: "/tmp/apar.csv"
     flrtvczip: "{{protocol}}://{{localpatchserver}}/{{localpatchpath}}/FLRTVC-latest.zip"
     apar_csv_url: "{{protocol}}://{{localpatchserver}}/{{localpatchpath}}/apar.csv"
+    debug: false
   collections:
     - ibm.power_aix
   tasks:
@@ -22,7 +23,7 @@
         cmd: "wget -q --no-check-certificate {{ apar_csv_url }} -O {{ apar_csv }}"
 
     - name: install all security interim fixes
-      flrtvc:
+      ibm.power_aix.flrtvc:
         apar: "sec"
         verbose: true
         protocol: "{{ protocol }}"
@@ -38,5 +39,7 @@
         https_proxy: ""
         PATH: "/usr/bin:/usr/sbin:/usr/local/bin:/opt/freeware/bin"
 
-    - debug:
+    - name: debug reg_install
+      ansible.builtin.debug:
         var: reg_install
+      when: debug

--- a/playbooks/demo_flrtvc_local_patch_server.yml
+++ b/playbooks/demo_flrtvc_local_patch_server.yml
@@ -1,0 +1,42 @@
+---
+#ptsiamis@gmail.com
+#Demo playbook
+#Create a local nginx with the patches
+#Download patches with playbook:
+#demo_shell_flrtvc_wget_ifix.yml
+- name: "Demo install ifix from flrtvc from local patch server"
+  hosts: all
+  gather_facts: no
+  vars:
+    localpatchserver: "192.168.1.1"
+    localpatchpath: "ifix"
+    protocol: "https"
+    apar_csv: "/tmp/apar.csv"
+    flrtvczip: "{{protocol}}://{{localpatchserver}}/{{localpatchpath}}/FLRTVC-latest.zip"
+    apar_csv_url: "{{protocol}}://{{localpatchserver}}/{{localpatchpath}}/apar.csv"
+  collections:
+    - ibm.power_aix
+  tasks:
+    - name: Download apar.csv to {{ apar_csv }} from {{ apar_csv_url }}
+      ansible.builtin.shell:
+        cmd: "wget -q --no-check-certificate {{ apar_csv_url }} -O {{ apar_csv }}"
+
+    - name: install all security interim fixes
+      flrtvc:
+        apar: "sec"
+        verbose: true
+        protocol: "{{ protocol }}"
+        force: no
+        clean: no
+        flrtvczip: "{{ flrtvczip }}"
+        localpatchserver: "{{ localpatchserver }}"
+        localpatchpath: "{{ localpatchpath }}"
+        csv: "{{ apar_csv }}"
+      register: reg_install
+      environment:
+        http_proxy: ""
+        https_proxy: ""
+        PATH: "/usr/bin:/usr/sbin:/usr/local/bin:/opt/freeware/bin"
+
+    - debug:
+        var: reg_install

--- a/playbooks/demo_shell_flrtvc_wget_ifix.yml
+++ b/playbooks/demo_shell_flrtvc_wget_ifix.yml
@@ -1,0 +1,70 @@
+---
+# ptsiamis@gmail.com
+# Simple sync on aap server
+# In order to server content you have to edit nginx as:
+# edit /etc/nginx/conf.d/automation-controller.nginx.conf
+# add: location /ifix { alias /var/lib/awx/ifix; autoindex on; }
+# Or create your own nginx server with a similar setup
+- name: "AIX sync all ifixes on webserver"
+  hosts: aap-server
+  gather_facts: no
+  vars:
+    ifix_path: "/var/lib/awx/ifix/"
+    ifix_url: "https://aix.software.ibm.com/aix/ifixes/security/"
+    apar_csv_url: "https://esupport.ibm.com/customercare/flrt/doc?page=aparCSV"
+    apar_csv_filename: "apar.csv"
+    flrtvc_url: "https://esupport.ibm.com/customercare/sas/f/flrt3/FLRTVC-latest.zip"
+    flrtvc_filename: "FLRTVC-latest.zip"
+    proxy: "http_proxy=YOURPROXYHERE:8080 https_proxy=$http_proxy"
+    debug: true
+    sync_ifix: true
+    sync_apar: true
+    sync_flrtvc: true
+  tasks:
+    - name: "Create ifix_path {{ ifix_path }} if not exists"
+      ansible.builtin.file:
+        path: "{{ ifix_path }}"
+        state: directory
+        mode: '0755'
+
+    - name: "Synchronizing ifix to {{ ifix_path }} from {{ ifix_url }} "
+      ansible.builtin.shell:
+        cmd: "{{ proxy }} wget -q -nc -r -np -nd --no-check-certificate  -l 1 -A .tar,.asc,.sig  {{ ifix_url }} "
+        chdir: "{{ ifix_path }}"
+      register: ifixd
+      when: sync_ifix
+
+    - name: print debug
+      debug:
+        var: ifixd
+      when: sync_ifix
+
+    - name: "Synchronizing {{ ifix_path }}/{{ apar_csv_filename }} from {{ apr_csv_url }}"
+      ansible.builtin.shell:
+        cmd: "{{ proxy }} wget -k {{ apar_csv_url }} -O {{ apar_csv_filename }}"
+        chdir: "{{ ifix_path }}"
+      register: apard
+      when: sync_apar
+
+    - name: print debug
+      debug:
+        var: apard
+      when: sync_apar
+
+    - name: "Synchronizing {{ ifix_path }}/{{ flrtvc_filename }} from {{ flrtvc_url }}"
+      ansible.builtin.shell:
+        cmd: "{{ proxy }} wget -k {{ flrtvc_url }} -O {{ flrtvc_filename }}"
+        chdir: "{{ ifix_path }}"
+      register: flrtvcd
+      when: sync_flrtvc
+
+    - name: print debug
+      debug:
+        var: flrtvcd
+      when: sync_flrtvc
+
+    - name: "Recursive fix permissions on ifix_path {{ ifix_path }}"
+      ansible.builtin.file:
+        path: "{{ ifix_path }}"
+        mode: "u=rwX,g=rwX,o=rX"
+        recurse: yes

--- a/playbooks/demo_shell_flrtvc_wget_ifix.yml
+++ b/playbooks/demo_shell_flrtvc_wget_ifix.yml
@@ -16,7 +16,7 @@
     flrtvc_url: "https://esupport.ibm.com/customercare/sas/f/flrt3/FLRTVC-latest.zip"
     flrtvc_filename: "FLRTVC-latest.zip"
     proxy: "http_proxy=YOURPROXYHERE:8080 https_proxy=$http_proxy"
-    debug: true
+    debug: false
     sync_ifix: true
     sync_apar: true
     sync_flrtvc: true
@@ -34,10 +34,12 @@
       register: ifixd
       when: sync_ifix
 
-    - name: print debug
-      debug:
+    - name: print ifixd
+      ansible.builtin.debug:
         var: ifixd
-      when: sync_ifix
+      when: 
+        - sync_ifix
+        - debug
 
     - name: "Synchronizing {{ ifix_path }}/{{ apar_csv_filename }} from {{ apr_csv_url }}"
       ansible.builtin.shell:
@@ -46,10 +48,12 @@
       register: apard
       when: sync_apar
 
-    - name: print debug
-      debug:
+    - name: print apard
+      ansible.builtin.debug:
         var: apard
-      when: sync_apar
+      when: 
+        - sync_apar
+        - debug
 
     - name: "Synchronizing {{ ifix_path }}/{{ flrtvc_filename }} from {{ flrtvc_url }}"
       ansible.builtin.shell:
@@ -58,10 +62,12 @@
       register: flrtvcd
       when: sync_flrtvc
 
-    - name: print debug
-      debug:
+    - name: print flrtvcd
+      ansible.builtin.debug:
         var: flrtvcd
-      when: sync_flrtvc
+      when: 
+        - sync_flrtvc
+        - debug
 
     - name: "Recursive fix permissions on ifix_path {{ ifix_path }}"
       ansible.builtin.file:

--- a/plugins/modules/flrtvc.py
+++ b/plugins/modules/flrtvc.py
@@ -1060,8 +1060,7 @@ def run_parser(report, localpatchserver, localpatchpath):
     if localpatchpath != "":
         rule2 = r'/(aix/ifixes/.*?/|aix/efixes/security/.*?.tar|' + localpatchpath + '/.*?.tar)$'
 
-    pattern = re.compile(rule1 +
-                         rule2)
+    pattern = re.compile(rule1 + rule2)
 
     rows = []
     for row in dict_rows:

--- a/plugins/modules/flrtvc.py
+++ b/plugins/modules/flrtvc.py
@@ -120,6 +120,24 @@ options:
     - When set, downloads will be attempted using set protocol.
     type: str
     choices: [ https, http, ftp ]
+  flrtvczip:
+    description:
+    - Specifies alternative location (local repository) hosting flrtvc.zip file.
+    - When set, download of FLRTVC-Latest.zip will be attempted from this url.
+    type: str
+    default: "https://esupport.ibm.com/customercare/sas/f/flrt3/FLRTVC-latest.zip"
+  localpatchserver:
+    description:
+    - Specifies local server ip/hostname containing ifix patches.
+    - When set, urls from frltvc.ksh will replaced with localpatchserver to point to local server.
+    type: str
+    default: no
+  localpatchpath:
+    description:
+    - Specifies local server path containing ifix patches.
+    - When set, sub paths from frltvc.ksh containing patches will replaced with localpatchpath to point to local path.
+    type: str
+    default: no
 notes:
   - Refer to the FLRTVC page for detail on the script.
     U(https://esupport.ibm.com/customercare/flrt/sas?page=../jsp/flrtvc.jsp)
@@ -130,6 +148,9 @@ notes:
     be updated.
   - When the FLRTVC ksh script cannot execute the emgr command, it tries with B(sudo), so you can
     try installing B(sudo) on the managed system.
+  - When use local patch server settings  localpatchserver and localpatchpath must be both set 
+    in order to have a complete full url with patches, for example the local url
+    192.168.1.100/ifix should become in module localpatchserver 192.168.1.100 and localpatchpath ifix.
 '''
 
 EXAMPLES = r'''
@@ -147,6 +168,15 @@ EXAMPLES = r'''
     verbose: true
     force: false
     clean: false
+
+- name: Install patches from local patch server
+  flrtvc:
+    apar: sec
+    protocol: https
+    localpatchserver: 192.168.1.1
+    localpatchpath: ifix
+    flrtvczip: https://192.168.1.1/ifix/flrtvc.zip
+    csv: https://192.168.1.1/ifix/apar.csv
 '''
 
 RETURN = r'''
@@ -1012,7 +1042,7 @@ def run_flrtvc(flrtvc_path, params, force):
     return True
 
 
-def run_parser(report):
+def run_parser(report, localpatchserver, localpatchpath):
     """
     Parse report by extracting URLs
     args:
@@ -1023,16 +1053,27 @@ def run_parser(report):
 
     protocol = module.params['protocol']
     dict_rows = csv.DictReader(report, delimiter='|')
-    pattern = re.compile(r'^(http|https|ftp)://(aix.software.ibm.com|public.dhe.ibm.com)'
-                         r'/(aix/ifixes/.*?/|aix/efixes/security/.*?.tar)$')
+    rule1 = r'^(http|https|ftp)://(aix.software.ibm.com|public.dhe.ibm.com)'
+    rule2 = r'/(aix/ifixes/.*?/|aix/efixes/security/.*?.tar)$'
+    if localpatchserver != "" :
+      rule1 = r'^(http|https|ftp)://(aix.software.ibm.com|public.dhe.ibm.com|' + localpatchserver + ')'
+    if localpatchpath != "" :
+      rule2 = r'/(aix/ifixes/.*?/|aix/efixes/security/.*?.tar|' + localpatchpath + '/.*?.tar)$'
+
+    pattern = re.compile(rule1 +
+                         rule2)
 
     rows = []
     for row in dict_rows:
         row = row['Download URL']
         if protocol:
             row = re.sub(r'^(https|http|ftp)', protocol, row, count=1)
-
+        if localpatchserver:
+            row = re.sub(r'://(aix.software.ibm.com|public.dhe.ibm.com)/', '://' + localpatchserver + '/', row, count=1)
+        if localpatchpath:
+            row = re.sub(r'/(aix/ifixes/|aix/efixes/security)/', '/' + localpatchpath + '/', row, count=1)
         rows.append(row)
+
     selected_rows = [row for row in rows if pattern.match(row) is not None]
     rows = list(set(selected_rows))  # remove duplicates
     debug_len = len(rows)
@@ -1245,6 +1286,9 @@ def main():
             download_only=dict(required=False, type='bool', default=False),
             extend_fs=dict(required=False, type='bool', default=True),
             protocol=dict(required=False, type='str', choices=['https', 'http', 'ftp']),
+            localpatchserver=dict(required=False, type='str', default=""),
+            localpatchpath=dict(required=False, type='str', default=""),
+            flrtvczip=dict(required=False, type='str', default='https://esupport.ibm.com/customercare/sas/f/flrt3/FLRTVC-latest.zip'),
         ),
         supports_check_mode=True
     )
@@ -1284,6 +1328,9 @@ def main():
     check_only = module.params['check_only']
     download_only = module.params['download_only']
     resize_fs = module.params['extend_fs']
+    flrtvczip = module.params['flrtvczip']
+    localpatchserver = module.params['localpatchserver']
+    localpatchpath = module.params['localpatchpath']
 
     # Create working directory if needed
     workdir = os.path.abspath(os.path.join(flrtvc_params['dst_path'], 'work'))
@@ -1306,8 +1353,7 @@ def main():
             results['meta']['messages'].append(msg)
 
     flrtvc_dst = os.path.abspath(os.path.join(workdir, 'FLRTVC-latest.zip'))
-    if not download('https://esupport.ibm.com/customercare/sas/f/flrt3/FLRTVC-latest.zip',
-                    flrtvc_dst, resize_fs):
+    if not download(flrtvczip, flrtvc_dst, resize_fs):
         if clean and os.path.exists(workdir):
             shutil.rmtree(workdir, ignore_errors=True)
         results['msg'] = 'Failed to download FLRTVC-latest.zip'
@@ -1344,7 +1390,7 @@ def main():
     # Parse flrtvc report
     # ===========================================
     module.debug('*** PARSE ***')
-    run_parser(results['meta']['0.report'])
+    run_parser(results['meta']['0.report'], localpatchserver, localpatchpath)
 
     # ===========================================
     # Download and check efixes

--- a/plugins/modules/flrtvc.py
+++ b/plugins/modules/flrtvc.py
@@ -148,7 +148,7 @@ notes:
     be updated.
   - When the FLRTVC ksh script cannot execute the emgr command, it tries with B(sudo), so you can
     try installing B(sudo) on the managed system.
-  - When use local patch server settings  localpatchserver and localpatchpath must be both set 
+  - When use local patch server settings  localpatchserver and localpatchpath must be both set
     in order to have a complete full url with patches, for example the local url
     192.168.1.100/ifix should become in module localpatchserver 192.168.1.100 and localpatchpath ifix.
 '''
@@ -1055,10 +1055,10 @@ def run_parser(report, localpatchserver, localpatchpath):
     dict_rows = csv.DictReader(report, delimiter='|')
     rule1 = r'^(http|https|ftp)://(aix.software.ibm.com|public.dhe.ibm.com)'
     rule2 = r'/(aix/ifixes/.*?/|aix/efixes/security/.*?.tar)$'
-    if localpatchserver != "" :
-      rule1 = r'^(http|https|ftp)://(aix.software.ibm.com|public.dhe.ibm.com|' + localpatchserver + ')'
-    if localpatchpath != "" :
-      rule2 = r'/(aix/ifixes/.*?/|aix/efixes/security/.*?.tar|' + localpatchpath + '/.*?.tar)$'
+    if localpatchserver != "":
+        rule1 = r'^(http|https|ftp)://(aix.software.ibm.com|public.dhe.ibm.com|' + localpatchserver + ')'
+    if localpatchpath != "":
+        rule2 = r'/(aix/ifixes/.*?/|aix/efixes/security/.*?.tar|' + localpatchpath + '/.*?.tar)$'
 
     pattern = re.compile(rule1 +
                          rule2)


### PR DESCRIPTION
Includes the abillity to local clone in an http server the packages from ibm ifix  thus avoiding the usage of internet/proxy in the aix systems. The method is simple you specify your server and the path of the patches and the flrtvc module replaces the urls from flrtvc.ksh to the desired local ones. It will need of course to be set with apar_csv in order to find a local copy of apar.csv. See demo playbooks for this.