### PR TITLE
Changed required python version for all the modules

### DIFF
--- a/plugins/modules/_nim_upgradeios.py
+++ b/plugins/modules/_nim_upgradeios.py
@@ -26,7 +26,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 options:
   action:
     description:

--- a/plugins/modules/aixpert.py
+++ b/plugins/modules/aixpert.py
@@ -28,7 +28,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization: B(aix.security.aixpert)'
 options:
   mode:

--- a/plugins/modules/alt_disk.py
+++ b/plugins/modules/alt_disk.py
@@ -27,7 +27,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations: B(aix.system.install,aix.lvm.manage.change)'
 options:
   action:

--- a/plugins/modules/backup.py
+++ b/plugins/modules/backup.py
@@ -29,7 +29,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization: B(aix.system.install)'
 options:
   action:

--- a/plugins/modules/bootlist.py
+++ b/plugins/modules/bootlist.py
@@ -25,7 +25,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - Root user or member of security group is required.
 options:
   force:

--- a/plugins/modules/bosboot.py
+++ b/plugins/modules/bosboot.py
@@ -26,7 +26,7 @@ description:
   version_added:'1.6.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization:
   B(aix.system.install)'
 options:

--- a/plugins/modules/chsec.py
+++ b/plugins/modules/chsec.py
@@ -28,7 +28,7 @@ author:
   - Stephen Ulmer (@stephenulmer)
 requirements:
   - AIX
-  - Python >= 2.7
+  - Python >= 3.6
   - 'Privileged user with authorizations'
 options:
   file:

--- a/plugins/modules/devices.py
+++ b/plugins/modules/devices.py
@@ -28,7 +28,7 @@ description:
 version_added: '1.0.0'
 requirements:
 - AIX
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations:
   B(aix.device.manage.change,aix.device.manage.remove,aix.device.config)'
 options:

--- a/plugins/modules/emgr.py
+++ b/plugins/modules/emgr.py
@@ -28,7 +28,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization: B(aix.system.install)'
 options:
   action:

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -24,7 +24,7 @@ description:
 version_added: '1.0.0'
 requirements:
 - AIX
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations:
   B(aix.fs.manage.list,aix.fs.manage.create,aix.fs.manage.change,aix.fs.manage.remove,aix.network.nfs.mount)'
 options:

--- a/plugins/modules/flrtvc.py
+++ b/plugins/modules/flrtvc.py
@@ -43,7 +43,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations: B(aix.fs.manage.change,aix.system.install)'
 - 'set environment as PATH: "/usr/bin:/usr/sbin/:/opt/freeware/bin"'
 options:

--- a/plugins/modules/geninstall.py
+++ b/plugins/modules/geninstall.py
@@ -24,7 +24,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization: B(aix.system.install)'
 options:
   action:

--- a/plugins/modules/getconf.py
+++ b/plugins/modules/getconf.py
@@ -26,7 +26,7 @@ description:
 version_added: '1.7.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 options:
   variable:
     description:

--- a/plugins/modules/group.py
+++ b/plugins/modules/group.py
@@ -25,7 +25,7 @@ description:
 version_added: '1.0.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations:
   B(aix.security.group.remove.admin,aix.security.group.remove.normal,
   aix.security.group.create.admin,aix.security.group.create.normal,aix.security.group.list)'

--- a/plugins/modules/hdcrypt_conv.py
+++ b/plugins/modules/hdcrypt_conv.py
@@ -26,7 +26,7 @@ description:
 version_added: '1.7.0'
 requirements:
 - AIX >= 72X
-- Python >= 2.7
+- Python >= 3.6
 options:
   action:
     description:

--- a/plugins/modules/inittab.py
+++ b/plugins/modules/inittab.py
@@ -23,7 +23,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization: B(aix.system.config.inittab)'
 options:
     state:

--- a/plugins/modules/install_all_updates.py
+++ b/plugins/modules/install_all_updates.py
@@ -25,7 +25,7 @@ description:
 version_added: '1.8.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization: B(aix.system.install)'
 options:
   device:

--- a/plugins/modules/installp.py
+++ b/plugins/modules/installp.py
@@ -25,7 +25,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization: B(aix.system.install)'
 options:
   action:

--- a/plugins/modules/lpar_facts.py
+++ b/plugins/modules/lpar_facts.py
@@ -23,7 +23,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 options: {}
 notes:
   - You can refer to the IBM documentation for additional information on the lparstat command at

--- a/plugins/modules/lpp_facts.py
+++ b/plugins/modules/lpp_facts.py
@@ -24,7 +24,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 options:
   filesets:
     description:

--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -26,7 +26,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations:
   B(aix.lvm.manage.extend,aix.lvm.manage.change,aix.lvm.manage.create,aix.lvm.manage.remove)'
 options:

--- a/plugins/modules/lvm_facts.py
+++ b/plugins/modules/lvm_facts.py
@@ -27,7 +27,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 options:
   name:
     description:

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -24,7 +24,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations:
   B(aix.lvm.manage.change,aix.lvm.manage.create,aix.lvm.manage.remove)'
 options:

--- a/plugins/modules/mkfilt.py
+++ b/plugins/modules/mkfilt.py
@@ -24,7 +24,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations:
   B(aix.security.network.filt,aix.security.network.stat,aix.device.manage.create)'
 options:

--- a/plugins/modules/mktcpip.py
+++ b/plugins/modules/mktcpip.py
@@ -24,7 +24,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization: B(aix.network.config.tcpip)'
 options:
   hostname:

--- a/plugins/modules/mktun.py
+++ b/plugins/modules/mktun.py
@@ -30,7 +30,7 @@ description:
 version_added: '1.2.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations: B(aix.security.network.vpn,aix.security.network.stat)'
 options:
   manual:

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -25,7 +25,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations:
   B(aix.fs.manage.list,aix.fs.manage.create,aix.fs.manage.change,aix.fs.manage.remove,aix.fs.manage.mount,aix.fs.manage.unmount)'
 options:

--- a/plugins/modules/mpio.py
+++ b/plugins/modules/mpio.py
@@ -23,7 +23,7 @@ description:
 version_added: '1.1.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 options:
   device:
     description:

--- a/plugins/modules/nim.py
+++ b/plugins/modules/nim.py
@@ -25,7 +25,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - User with root authority to run the nim command.
 - 'Privileged user with authorization:
   B(aix.system.install,aix.system.nim.config.server,aix.system.nim.stat)'

--- a/plugins/modules/nim_backup.py
+++ b/plugins/modules/nim_backup.py
@@ -27,7 +27,7 @@ description:
 version_added: '1.0.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:

--- a/plugins/modules/nim_flrtvc.py
+++ b/plugins/modules/nim_flrtvc.py
@@ -29,7 +29,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations:
   B(aix.fs.manage.change,aix.system.install,aix.system.nim.config.server)'
 options:

--- a/plugins/modules/nim_resource.py
+++ b/plugins/modules/nim_resource.py
@@ -22,7 +22,7 @@ description:
 version_added: '1.5.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - User with root authority to run the nim command.
 - NIM master software bos.sysmgt.nim.master.
 - 'Privileged user with authorization:

--- a/plugins/modules/nim_suma.py
+++ b/plugins/modules/nim_suma.py
@@ -26,7 +26,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:

--- a/plugins/modules/nim_updateios.py
+++ b/plugins/modules/nim_updateios.py
@@ -29,7 +29,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:

--- a/plugins/modules/nim_vios_alt_disk.py
+++ b/plugins/modules/nim_vios_alt_disk.py
@@ -23,7 +23,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:
   action:

--- a/plugins/modules/nim_vios_hc.py
+++ b/plugins/modules/nim_vios_hc.py
@@ -26,7 +26,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - The B(vioshc.py) script must be installed on the NIM master.
 - 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:

--- a/plugins/modules/nim_viosupgrade.py
+++ b/plugins/modules/nim_viosupgrade.py
@@ -27,7 +27,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.2 TL3
-- Python >= 2.7
+- Python >= 3.6
 - ios_mksysb VIOS level >= 3.1.0.0
 - 'Privileged user with authorizations: B(aix.system.install,aix.system.nim.config.server)'
 options:

--- a/plugins/modules/reboot.py
+++ b/plugins/modules/reboot.py
@@ -18,7 +18,7 @@ description:
 - Reboot a machine and validate by runnning a test command once the system comes back up.
 version_added: '1.1.0'
 requirements:
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorization: B(aix.system.boot.shutdown)'
 - In ansible.cfg file, ensure that ssh_args are properly set, so that ssh connection does not end up in a hang.
   For example, ssh_args = -o ForwardAgent=yes -o ControlPersist=30m -o ServerAliveInterval=45 -o ServerAliveCountMax=10

--- a/plugins/modules/smtctl.py
+++ b/plugins/modules/smtctl.py
@@ -28,7 +28,7 @@ version_added: '1.3.0'
 requirements:
 - AIX  7.2
 - IBM Power9_Power8
-- Python >= 2.7
+- Python >= 3.6
 options:
   smt_value:
     description:

--- a/plugins/modules/suma.py
+++ b/plugins/modules/suma.py
@@ -32,7 +32,7 @@ description:
 version_added: '0.4.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - 'Privileged user with authorizations: B(aix.system.install)'
 options:
   action:

--- a/plugins/modules/tunables.py
+++ b/plugins/modules/tunables.py
@@ -18,7 +18,7 @@ description:
 version_added: '1.5.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - Root user is required.
 options:
   action:

--- a/plugins/modules/tunfile_mgmt.py
+++ b/plugins/modules/tunfile_mgmt.py
@@ -18,7 +18,7 @@ description:
 version_added: '1.5.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - Root user is required.
 options:
   action:

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -25,7 +25,7 @@ description:
 version_added: '1.0.0'
 requirements:
 - AIX >= 7.1 TL3
-- Python >= 2.7
+- Python >= 3.6
 - Root user is required.
 - 'Privileged user with authorizations:
   B(aix.security.user.remove.admin,aix.security.user.remove.normal,aix.security.user.create.admin,aix.security.user.create.normal,,aix.security.user.change,aix.security.user.list)'


### PR DESCRIPTION
After recent updates to the modules, some new features like f-strings are now being used. Some of these (eg: f-strings) were introduced in python version 3.6. The documentation needs to change accordingly.