### PR TITLE
fix TypeError: 'int' object is not subscriptable when size Unit is M

### DIFF
--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -343,7 +343,7 @@ def compare_attrs(module):
                     val = int(val[:-1])
                     if val % 64 != 0:
                         val = str(((val // 64) + 1) * 64)
-                if str(val[-1]) == "G":
+                if str(val)[-1] == "G":
                     val = int(val[:-1])
                     val = str(val * 1024)
                 block_size = int(current_attributes["block size"]) // 1024


### PR DESCRIPTION
fix TypeError: 'int' object is not subscriptable when size is declared in M

When size attr is defined in M, the follow-up evaluation for unit "G" fails:

~~~
module_stdout: ''
module_stderr: |
  Traceback (most recent call last):
    File "<stdin>", line 107, in <module>
    File "<stdin>", line 99, in _ansiballz_main
    File "<stdin>", line 47, in invoke_module
    File "/opt/freeware/lib64/python3.9/runpy.py", line 225, in run_module
      return _run_module_code(code, init_globals, run_name, mod_spec)
    File "/opt/freeware/lib64/python3.9/runpy.py", line 97, in _run_module_code
      _run_code(code, mod_globals, init_globals,
    File "/opt/freeware/lib64/python3.9/runpy.py", line 87, in _run_code
      exec(code, run_globals)
    File "/tmp/ansible_ibm.power_aix.filesystem_payload_qdt75g7p/ansible_ibm.power_aix.filesystem_payload.zip/ansible_collections/ibm/power_aix/plugins/modules/filesystem.py", line 624, in <module>
    File "/tmp/ansible_ibm.power_aix.filesystem_payload_qdt75g7p/ansible_ibm.power_aix.filesystem_payload.zip/ansible_collections/ibm/power_aix/plugins/modules/filesystem.py", line 609, in main
    File "/tmp/ansible_ibm.power_aix.filesystem_payload_qdt75g7p/ansible_ibm.power_aix.filesystem_payload.zip/ansible_collections/ibm/power_aix/plugins/modules/filesystem.py", line 435, in chfs
    File "/tmp/ansible_ibm.power_aix.filesystem_payload_qdt75g7p/ansible_ibm.power_aix.filesystem_payload.zip/ansible_collections/ibm/power_aix/plugins/modules/filesystem.py", line 346, in compare_attrs
  TypeError: 'int' object is not subscriptable
exception: |
  Traceback (most recent call last):
    File "<stdin>", line 107, in <module>
    File "<stdin>", line 99, in _ansiballz_main
    File "<stdin>", line 47, in invoke_module
    File "/opt/freeware/lib64/python3.9/runpy.py", line 225, in run_module
      return _run_module_code(code, init_globals, run_name, mod_spec)
    File "/opt/freeware/lib64/python3.9/runpy.py", line 97, in _run_module_code
      _run_code(code, mod_globals, init_globals,
    File "/opt/freeware/lib64/python3.9/runpy.py", line 87, in _run_code
      exec(code, run_globals)
    File "/tmp/ansible_ibm.power_aix.filesystem_payload_qdt75g7p/ansible_ibm.power_aix.filesystem_payload.zip/ansible_collections/ibm/power_aix/plugins/modules/filesystem.py", line 624, in <module>
    File "/tmp/ansible_ibm.power_aix.filesystem_payload_qdt75g7p/ansible_ibm.power_aix.filesystem_payload.zip/ansible_collections/ibm/power_aix/plugins/modules/filesystem.py", line 609, in main
    File "/tmp/ansible_ibm.power_aix.filesystem_payload_qdt75g7p/ansible_ibm.power_aix.filesystem_payload.zip/ansible_collections/ibm/power_aix/plugins/modules/filesystem.py", line 435, in chfs
    File "/tmp/ansible_ibm.power_aix.filesystem_payload_qdt75g7p/ansible_ibm.power_aix.filesystem_payload.zip/ansible_collections/ibm/power_aix/plugins/modules/filesystem.py", line 346, in compare_attrs
  TypeError: 'int' object is not subscriptable
msg: |-
  MODULE FAILURE
  See stdout/stderr for the exact error
rc: 1
_ansible_no_log: false
changed: false
item:
  filesystem: /admin
  size: 256M
  fs_check:
    active: 'no'
ansible_loop_var: item
_ansible_item_label:
  filesystem: /admin
  size: 256M
  fs_check:
    active: 'no'
~~~