### PR TITLE
Fix typo in f-string

### DIFF
--- a/plugins/modules/alt_disk.py
+++ b/plugins/modules/alt_disk.py
@@ -309,7 +309,7 @@ def find_valid_altdisk(module, hdisks, rootvg_info, disk_size_policy, force, all
             if ret != 0:
                 results['stdout'] = stdout
                 results['stderr'] = stderr
-                results['msg'] = 'fCommand \'{ cmd }\' failed with RC { ret }.'
+                results['msg'] = f'Command \'{ cmd }\' failed with RC { ret }.'
                 module.fail_json(**results)
 
         # Clean existing old_rootvg


### PR DESCRIPTION
Move f-string indicator 'f' outside the quotes, to make sure string is treated as an f-string