### PR TITLE
Modified NIM ADM role - Added code for concurrent migration

### DIFF
--- a/roles/nim_alt_disk_migration/README.md
+++ b/roles/nim_alt_disk_migration/README.md
@@ -1,7 +1,7 @@
 # Ansible Role: nim_alt_disk_migration
 The [IBM Power Systems AIX](../../README.md) collection provides an 
 [Ansible role](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html), 
-referred to as `nim_alt_disk_migration`, which assists in automating in migration in 
+referred to as `nim_alt_disk_migration`, which assists in automating in 
 migration of AIX 7.1/7.2 to AIX 7.3.
 
 For guides and reference, see the [Docs Site](https://ibm.github.io/ansible-power-aix/roles.html).
@@ -33,7 +33,7 @@ Available variables are listed below, along with default values:
         <tr>
             <td><b> nim_alt_disk_migration_nim_client </b></td>
             <td>  </td>
-            <td> true </td>
+            <td> false </td>
             <td>  </td>
             <td>  </td>
             <td> 
@@ -44,7 +44,7 @@ Available variables are listed below, along with default values:
         <tr>
             <td><b> nim_alt_disk_migration_target_disk </b></td>
             <td>  </td>
-            <td> true </td>
+            <td> false </td>
             <td>  </td>
             <td>  </td>
             <td>  </td>
@@ -100,7 +100,7 @@ Available variables are listed below, along with default values:
         <tr>
             <td><b> nim_alt_disk_migration_lpp_source  </b></td>
             <td>  </td>
-            <td> true </td>
+            <td> false </td>
             <td>  </td>
             <td>  </td>
             <td> 
@@ -182,6 +182,29 @@ Available variables are listed below, along with default values:
             </td>
         </tr>
         <tr>
+            <td><b> nim_alt_disk_migration_prallel_migration </b></td>
+            <td>  </td>
+            <td> false </td>
+            <td> false </td>
+            <td>  </td>
+            <td> 
+                Specifies if multiple clients need to be migrated
+                parallely.
+            </td>
+        </tr>
+        <tr>
+            <td><b> nim_alt_disk_migration_client_data </b></td>
+            <td>  </td>
+            <td> false </td>
+            <td>  </td>
+            <td>  </td>
+            <td> 
+                Specifies location of the file containing information
+                about clients that need to be migrated in case of
+                parallel migration.
+            </td>
+        </tr>
+        <tr>
             <td><b> nim_alt_disk_migration_control_phases </b></td>
             <td>  </td>
             <td> false </td>
@@ -225,6 +248,14 @@ enough to contain the used PPs.
 variable is not required.
 - if a **nim_alt_disk_migration_spot** is not specified, one will be automatically created using the specified
 **nim_alt_disk_migration_lpp_source**.
+- In case of parallel migration, **nim_alt_disk_client_data** needs to be provided.
+- The JSON file containing information about the client needs to be created before triggering parallel migration.
+This file can be created using "nimadm -n -Y" command or manually.
+- In case of parallel migration, It is recommended to increase the proc_units allocated to the server for faster migration.
+If X number of CPU processors are dedicated to NIM master, then 3 x X clients can be migrated in parallel, efficiently.
+- Parallel migration is only possible with minimum AIX 7.3.3
+- Refer [nimadm documentation](https://www.ibm.com/docs/en/aix/7.3?topic=n-nimadm-command) for additional information
+related to parallel/concurrent migration.
 
 ## Dependencies
 

--- a/roles/nim_alt_disk_migration/defaults/main.yml
+++ b/roles/nim_alt_disk_migration/defaults/main.yml
@@ -35,3 +35,6 @@ nim_alt_disk_migration_spot: ""
 nim_alt_disk_migration_lpp_source_fileset_level: ""
 # Idempotency check.
 nim_alt_disk_migration_no_need_to_migrate: false
+
+# By default normal migration will run and not parallel migration
+nim_alt_disk_migration_parallel_migration: false

--- a/roles/nim_alt_disk_migration/meta/argument_specs.yml
+++ b/roles/nim_alt_disk_migration/meta/argument_specs.yml
@@ -2,7 +2,7 @@
 argument_specs:
   main:
     short_description: >
-      This role is used to migrate a client OS levels from
+      This role is used to migrate single/multiple client OS levels from
       AIX 7.1/7.2 to AIX 7.3.
     author:
       - Joseph de Joya
@@ -11,14 +11,14 @@ argument_specs:
     options:
       nim_alt_disk_migration_nim_client:
         type: str
-        required: true
+        required: false
         description: >
           Specifies a NIM object name that is associated to
           the NIM client LPAR to be migrated.
 
       nim_alt_disk_migration_target_disk:
         type: dict
-        required: true
+        required: false
         description: >
           Specifies the physical volume or a disk size policy
           used to automatically determine a valid physical volume
@@ -53,7 +53,7 @@ argument_specs:
 
       nim_alt_disk_migration_lpp_source:
         type: str
-        required: true
+        required: false
         description: >
           Specifies a NIM object name associated to a LPP
           resource for the desired level of migration.
@@ -107,7 +107,7 @@ argument_specs:
 
       nim_alt_disk_migration_control_phases:
         type: dict
-        required: true
+        required: false
         description: >
           Allows skipping or stopping at certain validations of
           the nim_alt_disk_migration role.

--- a/roles/nim_alt_disk_migration/meta/main.yml
+++ b/roles/nim_alt_disk_migration/meta/main.yml
@@ -5,7 +5,8 @@ galaxy_info:
     Joseph de Joya
     Rae Yang
     Pedro V Torres
-  description: Ansible role for migrating an alternate disk to a higher AIX level.
+    Shreyansh Chamola
+  description: Ansible role for migrating the client(s) to a higher AIX level.
   company: IBM
 
   license: GPL-3.0-only

--- a/roles/nim_alt_disk_migration/tasks/main.yml
+++ b/roles/nim_alt_disk_migration/tasks/main.yml
@@ -3,6 +3,111 @@
 #############################################################
 #############################################################
 
+# Code block for parallel/concurrent migration
+- name: Perform Parallel Migration
+  when: nim_alt_disk_migration_parallel_migration
+  block:
+    - name: Fail if nim_alt_disk_migration_nim_client is provided
+      when: nim_alt_disk_migration_nim_client|length != 0
+      ansible.builtin.fail:
+        msg: >
+          "'nim_alt_disk_migration_nim_client' and 'nim_alt_disk_migration_parallel_migration' are mutually exclusive."
+
+    - name: Fail if location of client data file is not provided
+      ansible.builtin.fail:
+        msg: You need to provide the location of file containing information about nim clients in case of parallel migration.
+      when: nim_alt_disk_migration_client_data|length == 0
+
+    - name: Fail if the client_data file's location is invalid
+      ansible.builtin.shell: |
+        ls {{ nim_alt_disk_migration_client_data }}
+      register: check_valid_location
+      changed_when: false
+      failed_when: check_valid_location.rc != 0
+
+    # Build command for parallel migration
+
+    - name: Basic command for parallel migration
+      ansible.builtin.set_fact:
+        parallel_migration_main_cmd: "nimadm -n -f {{ nim_alt_disk_migration_client_data }} -Y"
+
+    - name: Additional flags for the command if provided
+      block:
+        - name: Build command from empty string
+          ansible.builtin.set_fact:
+            additional_flags: ""
+
+        - name: Add default lpp source
+          when: nim_alt_disk_migration_lpp_source is defined and nim_alt_disk_migration_lpp_source|length != 0
+          ansible.builtin.set_fact:
+            additional_flags: "{{ additional_flags + ' -l ' + nim_alt_disk_migration_lpp_source }}"
+
+        - name: Add default spot
+          when: nim_alt_disk_migration_spot is defined and nim_alt_disk_migration_spot|length != 0
+          ansible.builtin.set_fact:
+            additional_flags: "{{ additional_flags + ' -s ' + nim_alt_disk_migration_spot }}"
+
+        - name: Add default installp bundle
+          when: nim_alt_disk_migration_nimadm_bundle is defined and nim_alt_disk_migration_nimadm_bundle|length != 0
+          ansible.builtin.set_fact:
+            additional_flags: "{{ additional_flags + ' -b ' + nim_alt_disk_migration_nimadm_bundle }}"
+
+        - name: Add default Pre-migration script if provided
+          when: nim_alt_disk_migration_nimadm_premig_script is defined and nim_alt_disk_migration_nimadm_premig_script|length != 0
+          ansible.builtin.set_fact:
+            additional_flags: "{{ additional_flags + ' -a ' + nim_alt_disk_migration_nimadm_premig_script }}"
+
+        - name: Add default Post-migration script if provided
+          when: nim_alt_disk_migration_nimadm_postmig_script is defined and nim_alt_disk_migration_nimadm_postmig_script|length != 0
+          ansible.builtin.set_fact:
+            additional_flags: "{{ additional_flags + ' -z ' +nim_alt_disk_migration_nimadm_postmig_script }}"
+
+    - name: Create the full command
+      when: additional_flags|length != 0
+      ansible.builtin.set_fact:
+        parallel_migration_main_cmd: "{{ parallel_migration_main_cmd + additional_flags }}"
+
+    - name: Display nimadm command for parallel migration
+      ansible.builtin.debug:
+        msg: "{{ parallel_migration_main_cmd }}"
+
+    - name: Run the parallel migration command
+      ansible.builtin.command: "{{ parallel_migration_main_cmd }}"
+      register: results
+      async: "{{ nim_alt_disk_migration_wait_nimadm_timeout_secs }}"
+      poll: 0
+      changed_when: true
+
+    - ansible.builtin.debug:  # var=results
+        msg:
+          - "timeout = {{ nim_alt_disk_migration_wait_nimadm_timeout_secs }} seconds or {{ nim_alt_disk_migration_wait_nimadm_timeout_hours }} hours "
+          - "Maximum retries: {{ nim_alt_disk_migration_retry_chk_nimadm_comp }} of {{ nim_alt_disk_migration_interval }} seconds"
+
+    - ansible.builtin.debug:
+        var: results
+
+    - name: "Polling until migration finishes (ignore FAILED RETRING messages) "
+      ansible.builtin.async_status:
+        jid: "{{ results.ansible_job_id }}"
+      register: async_poll_results
+      until: async_poll_results.finished
+      retries: "{{ nim_alt_disk_migration_retry_chk_nimadm_comp }}"
+      delay: "{{ nim_alt_disk_migration_interval }}"
+
+    - ansible.builtin.debug:  # var=async_poll_results
+        msg: retry = {{ nim_alt_disk_migration_retry_chk_nimadm_comp }}
+
+    - ansible.builtin.debug:
+        msg: '" PARALLEL MIGRATION COMPLETE!!!"'
+
+    - name: End play as parallel migration was completed
+      meta: end_host
+
+
+#############################################################
+#############################################################
+
+# This part will only run in case of single client migration
 - name: Fail if a NIM LPP resource is not specified
   ansible.builtin.fail:
     msg: NIM LPP resource not specified

--- a/roles/nim_alt_disk_migration/vars/main.yml
+++ b/roles/nim_alt_disk_migration/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # Copyright (c) IBM Corporation 2022
 # maximum time to wait for NIMADM to complete in hours
-nim_alt_disk_migration_wait_nimadm_timeout_hours: 4
+nim_alt_disk_migration_wait_nimadm_timeout_hours: 6
 
 # Maximum time to wait for NIMADM to complete in seconds
 nim_alt_disk_migration_wait_nimadm_timeout_secs: "{{ (nim_alt_disk_migration_wait_nimadm_timeout_hours * 60 * 60) | int }}"
@@ -22,3 +22,6 @@ nim_alt_disk_migration_dflt_retry_wait_time: 1
 # Location of the nim information file to store the nim_alt_disk_migration_lpp_source AIX level.
 # /var/adm/ras/ansible_nim_info_file_{{ nim_alt_disk_migration_lpp_source }}
 nim_alt_disk_migration_nim_info_file_path: /var/adm/ras/ansible_nim_info_file
+
+# Location of the file that contains data about clients upon which migration needs to be performed.
+nim_alt_disk_migration_client_data: ''


### PR DESCRIPTION
Added code for enabling Concurrent migration of multiple NIM clients in one go.

**Output**
```
TASK [ibm.power_aix.nim_alt_disk_migration : ansible.builtin.debug] ****************************************************************************************
task path: /ansible_collections/ibm/power_aix/roles/nim_alt_disk_migration/tasks/main.yml:96
ok: [root@XXXXXXXXXXXXXXXXXX] => {
    "msg": "retry = 361"
}

TASK [ibm.power_aix.nim_alt_disk_migration : ansible.builtin.debug] ****************************************************************************************
task path: /ansible_collections/ibm/power_aix/roles/nim_alt_disk_migration/tasks/main.yml:99
ok: [root@XXXXXXXXXXXXXXXXXX] => {
    "msg": "\" PARALLEL MIGRATION COMPLETE!!!\""
}

TASK [ibm.power_aix.nim_alt_disk_migration : End play as parallel migration was completed] *****************************************************************
task path: /ansible_collections/ibm/power_aix/roles/nim_alt_disk_migration/tasks/main.yml:102
META: ending play for root@XXXXXXXXXXXXXXXXXX

PLAY RECAP *************************************************************************************************************************************************
root@XXXXXXXXXXXXXXXXXX : ok=11   changed=2    unreachable=0    failed=0    skipped=8    rescued=0    ignored=0 
```