### PR TITLE
made changes in user module to fix the bug #637

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -5,9 +5,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-import re
-from ansible.module_utils.basic import AnsibleModule
-__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -124,6 +121,9 @@ stderr:
     returned: If the command failed.
     type: str
 '''
+import re
+from ansible.module_utils.basic import AnsibleModule
+__metaclass__ = type
 
 
 def get_chuser_command(module):

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -5,6 +5,9 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+import re
+from ansible.module_utils.basic import AnsibleModule
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -123,11 +126,6 @@ stderr:
 '''
 
 
-import re
-from ansible.module_utils.basic import AnsibleModule
-__metaclass__ = type
-
-
 def get_chuser_command(module):
     '''
     Returns the 'cmd' needed to run to implement changes on
@@ -173,10 +171,9 @@ def get_chuser_command(module):
 
         if str(user_attrs[attr]) != str(val):
             opts += f"{attr}=\"{val}\" "
-            opts = load_module_opts + opts
 
     if opts:
-        cmd = f"chuser {opts} {name}"
+        cmd = f"chuser {load_module_opts} {opts} {name}"
     if not cmd:
         # No change sare necessary.  It's best to return None instead of an empty string
         cmd = None


### PR DESCRIPTION
1: Fixed the issue, Regression in the user module between 1.9.x and 2.0.x #637 .
2: Changes the code for command 'chuser'  so that it will not add multiple -R option into command.

Output:

```  TASK [Verify the user info.] ************************************************************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]

TASK [assert] ***************************************************************************************************************************************************************************************************************************************
ok: [root@xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [remove user (cleanup task)] *******************************************************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]

TASK [debug] ****************************************************************************************************************************************************************************************************************************************
ok: [root@xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx] => {
    "output": {
        "changed": true,
        "failed": false,
        "msg": "User name is REMOVED SUCCESSFULLY: tester7"
    }
}

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************
root@xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx : ok=21   changed=13   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
 ``` 