### PR TITLE
Added documentation for alt_disk_install functionality.

### DIFF
--- a/plugins/modules/nim.py
+++ b/plugins/modules/nim.py
@@ -756,7 +756,9 @@ def expand_targets(targets):
 
 def perform_customization(module, lpp_source, target, is_async):
     """
-    Perform a customization of the given target client, applying the given lpp_source.
+    Applies the provided lpp_source.
+    If I(alt_disk_update_name) is provided, It performs alt_disk_install operation.
+    If not, performs the customization operation.
 
     arguments:
         module     (dict): The Ansible module.


### PR DESCRIPTION
Function "perform_customisation" was modified in PR #371 , "alt_disk_install" command was added to the function, but the documentation was not changed accordingly.

#366 Can be closed with this documentation change.