### PR TITLE
Add new vmstat modules

### DIFF
--- a/playbooks/demo_vmstat.yml
+++ b/playbooks/demo_vmstat.yml
@@ -1,0 +1,144 @@
+- name: Run vmstat command with various options on AIX
+  hosts: "{{ host_name }}"
+  gather_facts: false
+  vars:
+    host_name: usertest
+    user_name: aixguest
+    password_val: Password
+    ansible_remote_tmp: /tmp/vmstatdata
+    concat_v1: 'false'
+
+  tasks:
+    - name: Run vmstat with fork stats
+      ibm.power_aix.vmstat:
+        show_fork_stats: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 2
+        count: 5
+    - name: Run vmstat with show paging stats
+      ibm.power_aix.vmstat:
+        show_paging_stats: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        vmm_stats: true
+        large_page_stats: true
+        interval: 5
+        count: 10
+    - name: Run vmstat with only specific interrupts report
+      ibm.power_aix.vmstat:
+        show_interrupts: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 5
+        count: 10
+    - name: Run vmstat with hypervisor flag
+      ibm.power_aix.vmstat:
+        hypervisor_stats: true
+        io_view: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        with_fs_wait: true
+        timestamp: true
+        wide_output: true
+        vmm_stats: true
+        interval: 5
+        count: 5
+    - name: Run vmstat with specific option with wpar name 
+      ibm.power_aix.vmstat:
+        io_view: true
+        with_fs_wait: true
+        timestamp: true
+        wide_output: true
+        large_page_stats: true
+        concatenated_output: "{{ concat_v1 }}"
+        wpar_name: 'ALL'
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with pagesize_stats 
+      ibm.power_aix.vmstat:
+        io_view: true
+        with_fs_wait: true
+        timestamp: true
+        wide_output: true
+        concatenated_output: "{{ concat_v1 }}"
+        pagesize_stats: '4K'
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with page_stats_only 
+      ibm.power_aix.vmstat:
+        io_view: true
+        with_fs_wait: true
+        timestamp: true
+        wide_output: true
+        concatenated_output: "{{ concat_v1 }}"
+        page_stats_only: '4K'
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with scale power 
+      ibm.power_aix.vmstat:
+        scale_power: 2
+        with_fs_wait: true
+        timestamp: true
+        wide_output: true
+        concatenated_output: "{{ concat_v1 }}"
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with large_page_stats
+      ibm.power_aix.vmstat:
+        large_page_stats: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with timestamp
+      ibm.power_aix.vmstat:
+        timestamp: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with pagesize_stats
+      ibm.power_aix.vmstat:
+        pagesize_stats: '4k'
+        timestamp: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with page_stats_only
+      ibm.power_aix.vmstat:
+        page_stats_only: '4k'
+        timestamp: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with wpar_name
+      ibm.power_aix.vmstat:
+        wpar_name: 'ALL'
+        timestamp: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with show_paging_stats and vmm_stats
+      ibm.power_aix.vmstat:
+        show_paging_stats: true
+        vmm_stats: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 5
+        count: 2
+    - name: Run vmstat with specific option with hypervisor_stats and vmm_stats
+      ibm.power_aix.vmstat:
+        hypervisor_stats: true
+        vmm_stats: true
+        recorded_output: "/tmp/vmstatdata/vmstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 5
+        count: 2

--- a/plugins/modules/vmstat.py
+++ b/plugins/modules/vmstat.py
@@ -1,0 +1,342 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+DOCUMENTATION = r'''
+---
+module: vmstat
+author:
+  - AIX Development Team (@vivekpandeyibm)
+short_description: Run the AIX vmstat command to report system stats.
+description:
+  - Enables Ansible to invoke AIX's vmstat utility with full flag support.
+version_added: "2.1.0"
+requirements:
+  - AIX >= 7.1
+options:
+  show_fork_stats:
+    description:
+      - Reports the number of forks since system startup.
+    type: bool
+    default: false
+  show_interrupts:
+    description:
+      - Displays the number of interrupts by the device since system startup.
+    type: bool
+    default: false
+  show_paging_stats:
+    description:
+      - Shows the absolute count of paging events since system initialization.
+    type: bool
+    default: false
+  io_view:
+    description:
+      - Displays I/O-oriented view with additional I/O wait columns.
+    type: bool
+    default: false
+  with_fs_wait:
+    description:
+      - Adds file system wait column to I/O view. Used with C(io_view).
+    type: bool
+    default: false
+  timestamp:
+    description:
+      - Prints timestamp for each output line.
+    type: bool
+    default: false
+  vmm_stats:
+    description:
+      - Shows detailed VMM statistics.
+    type: bool
+    default: false
+  hypervisor_stats:
+    description:
+      - Shows hypervisor paging-related statistics.
+    type: bool
+    default: false
+  wide_output:
+    description:
+      - Enables wide mode display.
+    type: bool
+    default: false
+  large_page_stats:
+    description:
+      - Displays large page section details.
+    type: bool
+    default: false
+  recorded_output:
+    description:
+      - Folder path to command output in machine .
+    type: str
+  wpar_name:
+    description:
+      - Specifies WPAR name or ALL to report stats per WPAR.
+    type: str
+  pagesize_stats:
+    description:
+      - Appends stats for specified page size or physical volume (-p).
+    type: str
+  page_stats_only:
+    description:
+      - Displays only stats for specified page size or volume (-P).
+    type: str
+  scale_power:
+    description:
+      - Scaling factor for percentage values (e.g., 0-3 for 10^power).
+    type: int
+  interval:
+    description:
+      - Number of seconds between each report.
+    type: int
+  count:
+    description:
+      - Number of reports to generate. Used with C(interval).
+    type: int
+  concatenated_output:
+    description:
+      - Controls whether the output of the vmstat command is appended to the output file or is overwrited.
+      - If set to true, output will be appended to the file.
+      - If set to false, the file will be overwritten with fresh output.
+    type: bool
+    required: true
+
+notes:
+  - You can refer to the IBM documentation for additional information on the vmstat command at
+    U(https://www.ibm.com/docs/en/aix/7.3.0?topic=v-vmstat-command).
+'''
+
+EXAMPLES = r'''
+- name: Run vmstat with timestamp
+  vmstat_command:
+    timestamp: true
+    interval: 2
+    count: 5
+
+- name: Run vmstat with showing paging stat
+  vmstat_command:
+    show_paging_stats : true
+    wpar_name: "ALL"
+    interval: 1
+    count: 3
+'''
+
+RETURN = r'''
+cmd:
+  description: The full command run.
+  type: str
+stdout:
+  description: Command stdout.
+  type: str
+stderr:
+  description: Command stderr.
+  type: str
+rc:
+  description: Return code.
+  type: int
+changed:
+  description: Always true (command executed).
+  type: bool
+'''
+
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+
+def build_vmstat_command(module):
+    cmd = ['vmstat']
+
+    # Fail if more than one of -@, -p, -P is used together
+    count = sum([
+        bool(module.params['wpar_name']),
+        bool(module.params['pagesize_stats']),
+        bool(module.params['page_stats_only'])])
+
+    if count > 1:
+        module.fail_json(msg="Options -@, -p, and -P are mutually exclusive. Only one of them can be used at a time.")
+
+    # Fail: -S cannot be used with: -f, -s, -i, -v, -P
+    if module.params['scale_power'] is not None and (
+        module.params['show_fork_stats']
+        or module.params['show_paging_stats']
+        or module.params['show_interrupts']
+        or module.params['vmm_stats']
+        or module.params['page_stats_only']
+    ):
+        module.fail_json(msg="The -S option cannot be used with -f, -s, -i, -v, and -P.")
+
+    # Fail: -i  cannot be used with: -S, -@, -p, -P, -h
+    if module.params['show_interrupts'] and (
+        module.params['scale_power']
+        or module.params['wpar_name']
+        or module.params['pagesize_stats']
+        or module.params['page_stats_only']
+        or module.params['hypervisor_stats']
+    ):
+        module.fail_json(msg="The -i option cannot be used with -S, -@, -p, -P, or -h.")
+
+    # Fail:  -v cannot be used with: -p, -P when -s is not true
+    if module.params['vmm_stats'] and (module.params['pagesize_stats'] or module.params['page_stats_only']) and not module.params['show_paging_stats']:
+        module.fail_json(msg="The -v option cannot be used with -p or -P.")
+    # Fail:  -l cannot be used with: -p, -P
+    if module.params['large_page_stats'] and (module.params['pagesize_stats'] or module.params['page_stats_only']):
+        module.fail_json(msg="The -l option cannot be used with -p or -P.")
+
+        # Fail: -s  cannot be used with: -h, -P
+    if module.params['show_paging_stats'] and (module.params['hypervisor_stats'] or module.params['page_stats_only']):
+        module.fail_json(msg="The -s option cannot be used with -h, -P ")
+
+        # Fail: -h  cannot be used with: -p, -P, -s, -i
+    if module.params['hypervisor_stats'] and (
+        module.params['show_paging_stats']
+        or module.params['page_stats_only']
+        or module.params['pagesize_stats']
+        or module.params['show_interrupts']
+    ):
+        module.fail_json(msg="The -h option cannot be used with -s, -P, -p, -i")
+
+    if module.params['show_fork_stats']:
+        cmd.append('-f')
+
+    elif module.params['show_paging_stats']:
+        cmd.append('-s')
+        # Only valid combinations with -s
+        if module.params['vmm_stats']:
+            cmd.append('-v')
+        if module.params['large_page_stats']:
+            cmd.append('-l')
+        if module.params['wpar_name']:
+            cmd.extend(['-@', module.params['wpar_name']])
+        elif module.params['pagesize_stats']:
+            cmd.extend(['-p', module.params['pagesize_stats']])
+    elif module.params['show_interrupts']:
+        if not module.params['vmm_stats']:
+            cmd.append('-i')
+            if module.params['interval'] is not None:
+                cmd.append(str(module.params['interval']))
+                if module.params['count'] is not None:
+                    cmd.append(str(module.params['count']))
+    elif module.params['hypervisor_stats']:
+        cmd.append('-h')
+        # Only allow with -I, -t, -l, -w, and -v
+        if module.params['io_view']:
+            cmd.append('-I')
+            if module.params['with_fs_wait']:
+                cmd.append('-W')
+        if module.params['timestamp']:
+            cmd.append('-t')
+        if module.params['large_page_stats']:
+            cmd.append('-l')
+        if module.params['wide_output']:
+            cmd.append('-w')
+        if module.params['vmm_stats']:
+            cmd.append('-v')
+        if module.params['interval'] is not None:
+            cmd.append(str(module.params['interval']))
+            if module.params['count'] is not None:
+                cmd.append(str(module.params['count']))
+
+    else:
+        # If -vmm_stats is set  ignore other flags listed in image
+        if module.params['vmm_stats']:
+            cmd.append('-v')
+        else:
+            # Regular compatible flags
+            if module.params['io_view']:
+                cmd.append('-I')
+                if module.params['with_fs_wait']:
+                    cmd.append('-W')  # -W only valid with -I
+
+            if module.params['timestamp']:
+                cmd.append('-t')
+
+            if module.params['wide_output']:
+                cmd.append('-w')
+
+            if module.params['large_page_stats']:
+                cmd.append('-l')
+
+            if module.params['wpar_name']:
+                cmd.extend(['-@', module.params['wpar_name']])
+            elif module.params['pagesize_stats']:
+                cmd.extend(['-p', module.params['pagesize_stats']])
+            elif module.params['page_stats_only']:
+                cmd.extend(['-P', module.params['page_stats_only']])
+
+            # -S not allowed with -f, -s, -i, -v, -P
+            if module.params['scale_power']:
+                cmd.extend(['-S', str(module.params['scale_power'])])
+
+            # Interval and count: valid for general usage
+            if module.params['interval'] is not None:
+                cmd.append(str(module.params['interval']))
+                if module.params['count'] is not None:
+                    cmd.append(str(module.params['count']))
+
+    return cmd
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            show_fork_stats=dict(type='bool', default=False),
+            show_interrupts=dict(type='bool', default=False),
+            show_paging_stats=dict(type='bool', default=False),
+            io_view=dict(type='bool', default=False),
+            with_fs_wait=dict(type='bool', default=False),
+            timestamp=dict(type='bool', default=False),
+            vmm_stats=dict(type='bool', default=False),
+            hypervisor_stats=dict(type='bool', default=False),
+            wide_output=dict(type='bool', default=False),
+            large_page_stats=dict(type='bool', default=False),
+            concatenated_output=dict(type='bool', required=True),
+            wpar_name=dict(type='str'),
+            pagesize_stats=dict(type='str'),
+            page_stats_only=dict(type='str'),
+            scale_power=dict(type='int'),
+            recorded_output=dict(type='str'),
+            interval=dict(type='int'),
+            count=dict(type='int'),
+        ),
+        supports_check_mode=False
+    )
+
+    cmd = build_vmstat_command(module)
+    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
+
+    result = {
+        'changed': False,
+        'cmd': cmd,
+        'rc': rc,
+        'stdout': stdout,
+        'stderr': stderr
+    }
+
+    if rc != 0:
+        module.fail_json(msg=f'vmstat command failing with command {cmd} ', **result)
+    else:
+
+        if module.params['recorded_output']:
+            output_file = module.params['recorded_output']
+            should_concat = module.params['concatenated_output']
+            mode = 'a' if should_concat else 'w'  # 'a' = append, 'w' = overwrite
+            with open(output_file, mode) as f:
+                f.write(stdout + '\n')
+            result['changed'] = True
+            result['msg'] = f"vmstat executed successfully with command '{cmd}' and Output written to {output_file}"
+        else:
+            result['changed'] = False
+            result['msg'] = f"vmstat executed successfully with command '{cmd}'"
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
1: Create a new modules for vmstat command which reports statistics about kernel threads, virtual memory, disks, hypervisor pages, traps, and processor activity. Reports that are generated by the vmstat command can be used to balance system load activity.
2: vmstat command code file and playbook are added 

Output: 
``` TASK [Run vmstat with fork stats] ************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with show paging stats] *****************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with only specific interrupts report] ***************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with hypervisor flag] *******************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with wpar name] ****************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with pagesize_stats] ***********************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with page_stats_only] **********************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with scale power] **************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with large_page_stats] *********************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with timestamp] ****************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with pagesize_stats] ***********************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with page_stats_only] **********************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with wpar_name] ****************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with show_paging_stats and vmm_stats] ******************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

TASK [Run vmstat with specific option with hypervisor_stats and vmm_stats] *******************************************************************************************************************
changed: [root@xxxxxxxxxxxxx]

PLAY RECAP ***********************************************************************************************************************************************************************************
root@xxxxxxxxxxxxx : ok=15   changed=15   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
 ``` 
