### PR TITLE
Lintings and shellchecks reported by automation hub

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,18 +30,18 @@ Notes
 
 
 Availability
-  * `Automation Hub v2.0.3`_
-  * `Galaxy v2.0.3`_
-  * `GitHub v2.0.3`_
+  * `Automation Hub v2.1.0`_
+  * `Galaxy v2.1.0`_
+  * `GitHub v2.1.0`_
 
-.. _Automation Hub v2.0.3:
+.. _Automation Hub v2.1.0:
    https://cloud.redhat.com/ansible/automation-hub/ibm/power_aix
 
-.. _Galaxy v2.0.3:
-   https://galaxy.ansible.com/download/ibm-power_aix-2.0.3.tar.gz
+.. _Galaxy v2.1.0:
+   https://galaxy.ansible.com/download/ibm-power_aix-2.1.0.tar.gz
 
-.. _GitHub v2.0.3:
-   https://github.com/IBM/ansible-power-aix/raw/dev-collection/builds/ibm-power_aix-2.0.3.tar.gz
+.. _GitHub v2.1.0:
+   https://github.com/IBM/ansible-power-aix/raw/dev-collection/builds/ibm-power_aix-2.1.0.tar.gz
 
 Version 2.0.3
 -------------

--- a/playbooks/demo_hdcrypt_auth.yml
+++ b/playbooks/demo_hdcrypt_auth.yml
@@ -103,4 +103,3 @@
         auth_name: pwd1
         password: "Test1234567*"
       no_log: true
-

--- a/roles/power_aix_bootstrap/files/dnf_local.sh
+++ b/roles/power_aix_bootstrap/files/dnf_local.sh
@@ -1,4 +1,4 @@
-#!/bin/ksh
+#!/bin/sh
 # This scripts downloads the rpm.rte & dnf_bundle.tar
 # rpm.rte-4.13.0.x which is a prequisite for dnf.
 # dnf_bundle.tar contains dnf and its dependent packages.
@@ -6,13 +6,6 @@
 # already installed and then installs the packages accordingly.
 
 export LANG=C
-
-if [[ -e /usr/opt/rpm/bin/rpm ]]
-then
-    RPM_CMD="/usr/opt/rpm/bin/rpm"
-else
-    RPM_CMD="/usr/bin/rpm"
-fi
 
 # Check if we are running this as the root user.
 if [[ "$(id -u)" != "0" ]]
@@ -23,11 +16,11 @@ fi
 
 
 # First check the AIX version.
-oslvl=`/usr/bin/oslevel`
+oslvl=$(/usr/bin/oslevel)
 aix_ver=$(/usr/bin/lslpp -qLc bos.rte | /usr/bin/awk -F':' '{print $3}')
-af1=$(echo $aix_ver | /usr/bin/cut -d"." -f1)
-af2=$(echo $aix_ver | /usr/bin/cut -d"." -f2)
-af3=$(echo $aix_ver | /usr/bin/cut -d"." -f3)
+af1=$(echo "$aix_ver" | /usr/bin/cut -d"." -f1)
+af2=$(echo "$aix_ver" | /usr/bin/cut -d"." -f2)
+af3=$(echo "$aix_ver" | /usr/bin/cut -d"." -f3)
 if [[ "$oslvl" = "7.1.0.0" ]]
 then
     if [[ ( ! $af1 -ge 7 ) || ( ! $af2 -ge 1 ) || ( ! $af3 -ge 3 ) ]]
@@ -95,21 +88,21 @@ function print_openssl_err {
     exit 1
 }
 ssl_ver=$(lslpp -Lc openssl.base | /usr/bin/awk 'FNR==2' | /usr/bin/awk -F':' '{print $3}')
-f1=$(echo $ssl_ver | /usr/bin/cut -d"." -f1)
-f2=$(echo $ssl_ver | /usr/bin/cut -d"." -f2)
-f3=$(echo $ssl_ver | /usr/bin/cut -d"." -f3)
-f4=$(echo $ssl_ver | /usr/bin/cut -d"." -f4)
+f1=$(echo "$ssl_ver" | /usr/bin/cut -d"." -f1)
+f2=$(echo "$ssl_ver" | /usr/bin/cut -d"." -f2)
+#f3=$(echo "$ssl_ver" | /usr/bin/cut -d"." -f3)
+#f4=$(echo "$ssl_ver" | /usr/bin/cut -d"." -f4)
 if [[ ( ! $f1 -ge 1 ) ]] || [[ ( $f1 -eq  1 ) &&  ( ! $f2 -ge 1 ) ]]
 then
     print_openssl_err
 fi
 
-oslvl=`/usr/bin/oslevel`
+oslvl=$(/usr/bin/oslevel)
 aix_730_plus=0
-os_f1=$(echo $oslvl | /usr/bin/cut -d"." -f1)
-os_f2=$(echo $oslvl | /usr/bin/cut -d"." -f2)
-os_f3=$(echo $oslvl | /usr/bin/cut -d"." -f3)
-os_f4=$(echo $oslvl | /usr/bin/cut -d"." -f4)
+os_f1=$(echo "$oslvl" | /usr/bin/cut -d"." -f1)
+os_f2=$(echo "$oslvl" | /usr/bin/cut -d"." -f2)
+os_f3=$(echo "$oslvl" | /usr/bin/cut -d"." -f3)
+os_f4=$(echo "$oslvl" | /usr/bin/cut -d"." -f4)
 if [[ ( $os_f1 -ge 7 ) && ( $os_f2 -ge 3 ) && ( $os_f3 -ge 0 ) && ( $os_f4 -ge 0 ) ]]
 then
     aix_730_plus=1
@@ -123,8 +116,8 @@ fi
 
 if [[ $aix_730_plus -eq 1 ]]
 then
-    typeset -i total_req=`echo "(512)" | bc`
-    tmp_free=`/usr/bin/df -m /tmp | /usr/bin/sed -e /Filesystem/d | /usr/bin/awk '{print $3}'`
+    typeset -i total_req=$(echo "(512)" | bc)
+    tmp_free=$(/usr/bin/df -m /tmp | /usr/bin/sed -e /Filesystem/d | /usr/bin/awk '{print $3}')
     if [[ $tmp_free -le $total_req ]]
     then
         echo "Please make sure /tmp has around 512MB of free space to download and"
@@ -132,8 +125,8 @@ then
         exit 1
     fi
 else
-    typeset -i total_req=`echo "(512)" | bc`
-    tmp_free=`/usr/bin/df -m /tmp | /usr/bin/sed -e /Filesystem/d | /usr/bin/awk '{print $3}'`
+    typeset -i total_req=$(echo "(512)" | bc)
+    tmp_free=$(/usr/bin/df -m /tmp | /usr/bin/sed -e /Filesystem/d | /usr/bin/awk '{print $3}')
     if [[ $tmp_free -le $total_req ]]
     then
         echo "Please make sure /tmp has around 512MB of free space to download and"
@@ -144,13 +137,13 @@ fi
 
 
 # Check for specific directories related to the corrosponding OS level
-if [ $oslvl = "7.1.0.0" ] && [ ! -e ${mnt_path}/AIX_Toolbox_71 ]
+if [ "$oslvl" = "7.1.0.0" ] && [ ! -e "${mnt_path}"/AIX_Toolbox_71 ]
 then
     echo "No ${mnt_path}/AIX_Toolbox_71 repository path exists"
-elif [ $oslvl = "7.2.0.0" ] && [ ! -e ${mnt_path}/AIX_Toolbox_72 ]
+elif [ "$oslvl" = "7.2.0.0" ] && [ ! -e "${mnt_path}"/AIX_Toolbox_72 ]
 then
     echo "No ${mnt_path}//AIX_Toolbox_72 repository path exists"
-elif [ $oslvl = "7.3.0.0" ] && [ ! -e ${mnt_path}/AIX_Toolbox_73 ]
+elif [ "$oslvl" = "7.3.0.0" ] && [ ! -e "${mnt_path}"/AIX_Toolbox_73 ]
 then
     echo "No ${mnt_path}/AIX_Toolbox_73 repository path exists"
 fi
@@ -158,8 +151,8 @@ fi
 
 # Check if /opt is having enough space to install the packages from dnf_bundle.
 # Currently we need around 457MB of free space in /opt filesystem.
-typeset -i total_opt=`echo "(512)" | bc`
-opt_free=`/usr/bin/df -m /opt | /usr/bin/sed -e /Filesystem/d | /usr/bin/head -1 | /usr/bin/awk '{print $3}'`
+typeset -i total_opt=$(echo "(512)" | bc)
+opt_free=$(/usr/bin/df -m /opt | /usr/bin/sed -e /Filesystem/d | /usr/bin/head -1 | /usr/bin/awk '{print $3}')
 if [[ $opt_free -le $total_opt ]]
 then
     echo "Total free space required for /opt filesystem to install rpms"
@@ -169,10 +162,10 @@ then
 fi
 
 # Create a temporary directroy where the bundle is extracted.
-curr_time=`date +%Y%m%d%H%M%S`
-mkdir -p /tmp/dnf-$curr_time
-tmppath=`echo /tmp/dnf-$curr_time`
-cd $tmppath
+curr_time=$(date +%Y%m%d%H%M%S)
+mkdir -p /tmp/dnf-"$curr_time"
+tmppath=/tmp/dnf-"$curr_time"
+cd "$tmppath"
 
 #aix_ver=`oslevel -s | awk -F- '{printf "%.1f",$1/1000}'`
 
@@ -180,18 +173,15 @@ if [[ $aix_730_plus -eq 1 ]]
 then
     echo ""
     echo "Copying dnf_bundle_aix_73.tar to $tmppath ..... "
-    /usr/bin/cp $bundle_path/dnf_bundle_aix_73.tar $tmppath
-    if [ $? -ne 0 ]
-    then
+    if /usr/bin/cp "$bundle_path"/dnf_bundle_aix_73.tar "$tmppath"; then
         echo "Copy of dnf_bundle_aix_73.tar to $tmppath failed."
         exit 1
     fi
 else
     echo ""
     echo "Copying dnf_bundle_aix_71_72.tar to $tmppath ....."
-    /usr/bin/cp $bundle_path/dnf_bundle_aix_71_72.tar $tmppath
-    if [ $? -ne 0 ]
-    then
+    
+    if /usr/bin/cp "$bundle_path"/dnf_bundle_aix_71_72.tar "$tmppath"; then
         echo "Copy of dnf_bundle_aix_71_72.tar to $tmppath failed."
         exit 1
     fi
@@ -200,24 +190,24 @@ fi
 
 if [[ $aix_730_plus -eq 1 ]]
 then
-    echo "\nExtracting dnf_bundle_aix_73.tar ..."
+    printf "\nExtracting dnf_bundle_aix_73.tar ..."
     /usr/bin/tar -xvf dnf_bundle_aix_73.tar
 else
-    echo "\nExtracting dnf_bundle_aix_71_72.tar ..."
+    printf "\nExtracting dnf_bundle_aix_71_72.tar ..."
     /usr/bin/tar -xvf dnf_bundle_aix_71_72.tar
 fi
 
-./install_dnf.sh "$arg" $yum4 $yum3_instd 2
+./install_dnf.sh "$yum4" "$yum3_instd" 2
 rc=$?
 if [[ $rc -eq 0 ]]
 then
     cd - >/dev/null 2>&1
-    rm -rf $tmppath
+    rm -rf "$tmppath"
 elif [[ $rc -ne 0 ]]
 then
     echo "Please check the failure error, correct it and retry again."
     cd ~
-    rm -rf $tmppath
+    rm -rf "$tmppath"
     exit 1
 fi
 
@@ -229,63 +219,68 @@ echo "The default /opt/freeware/etc/dnf/dnf.conf has been saved as /opt/freeware
 CONF_FILE=/opt/freeware/etc/dnf/dnf.conf
 /usr/bin/mv /opt/freeware/etc/dnf/dnf.conf /opt/freeware/etc/dnf/dnf.conf_local_bak
 
-echo "[main]" > $CONF_FILE
-echo "cachedir=/var/cache/dnf" >> $CONF_FILE
-echo "keepcache=1" >> $CONF_FILE
-echo "debuglevel=2" >> $CONF_FILE
-echo "logfile=/var/log/dnf.log" >> $CONF_FILE
-echo "exactarch=1" >> $CONF_FILE
-echo "gpgcheck=1" >> $CONF_FILE
-echo "installonly_limit=3" >> $CONF_FILE
-echo "clean_requirements_on_remove=True" >> $CONF_FILE
-echo "best=True" >> $CONF_FILE
-echo "" >> $CONF_FILE
-echo "plugins=1" >> $CONF_FILE
-echo "" >> $CONF_FILE
-
-echo "[Local_AIX_Toolbox]" >> $CONF_FILE
-echo "name=Local AIX generic repository" >> $CONF_FILE
-echo "baseurl=file://${mnt_path}/AIX_Toolbox" >> $CONF_FILE
-echo "enabled=1" >> $CONF_FILE
-echo "gpgcheck=1" >> $CONF_FILE
-echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox" >> $CONF_FILE
-echo "" >> $CONF_FILE
-
-echo "[Local_AIX_Toolbox_noarch]" >> $CONF_FILE
-echo "name=Local AIX noarch repository" >> $CONF_FILE
-echo "baseurl=file://${mnt_path}/AIX_Toolbox_noarch" >> $CONF_FILE
-echo "enabled=1" >> $CONF_FILE
-echo "gpgcheck=1" >> $CONF_FILE
-echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox" >> $CONF_FILE
-echo "" >> $CONF_FILE
-
+{
+echo "[main]"
+echo "cachedir=/var/cache/dnf"
+echo "keepcache=1"
+echo "debuglevel=2"
+echo "logfile=/var/log/dnf.log"
+echo "exactarch=1"
+echo "gpgcheck=1"
+echo "installonly_limit=3"
+echo "clean_requirements_on_remove=True"
+echo "best=True"
+echo ""
+echo "plugins=1"
+echo ""
+echo "[Local_AIX_Toolbox]"
+echo "name=Local AIX generic repository"
+echo "baseurl=file://${mnt_path}/AIX_Toolbox"
+echo "enabled=1"
+echo "gpgcheck=1"
+echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox"
+echo ""
+echo "[Local_AIX_Toolbox_noarch]"
+echo "name=Local AIX noarch repository"
+echo "baseurl=file://${mnt_path}/AIX_Toolbox_noarch"
+echo "enabled=1"
+echo "gpgcheck=1"
+echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox"
+echo ""
+} >> $CONF_FILE
 if [ "$oslvl" = "7.1.0.0" ]
 then
-    echo "[Local_AIX_Toolbox_71]" >> $CONF_FILE
-    echo "name=Local AIX 7.1 specific repository" >> $CONF_FILE
-    echo "baseurl=file://${mnt_path}/AIX_Toolbox_71" >> $CONF_FILE
-    echo "enabled=1" >> $CONF_FILE
-    echo "gpgcheck=1" >> $CONF_FILE
-    echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox" >> $CONF_FILE
-    echo "" >> $CONF_FILE
+    {
+    echo "[Local_AIX_Toolbox_71]"
+    echo "name=Local AIX 7.1 specific repository"
+    echo "baseurl=file://${mnt_path}/AIX_Toolbox_71"
+    echo "enabled=1"
+    echo "gpgcheck=1"
+    echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox"
+    echo ""
+     } >> $CONF_FILE
 elif [ "$oslvl" = "7.2.0.0" ]
 then
-    echo "[Local_AIX_Toolbox_72]" >> $CONF_FILE
-    echo "name=Local AIX 7.2 specific repository" >> $CONF_FILE
-    echo "baseurl=file://${mnt_path}/AIX_Toolbox_72" >> $CONF_FILE
-    echo "enabled=1" >> $CONF_FILE
-    echo "gpgcheck=1" >> $CONF_FILE
-    echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox" >> $CONF_FILE
-    echo "" >> $CONF_FILE
+    {
+    echo "[Local_AIX_Toolbox_72]"
+    echo "name=Local AIX 7.2 specific repository"
+    echo "baseurl=file://${mnt_path}/AIX_Toolbox_72"
+    echo "enabled=1"
+    echo "gpgcheck=1"
+    echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox"
+    echo ""
+     } >> $CONF_FILE
 elif [ "$oslvl" = "7.3.0.0" ]
 then
-    echo "[Local_AIX_Toolbox_73]" >> $CONF_FILE
-    echo "name=Local AIX 7.3 specific repository" >> $CONF_FILE
-    echo "baseurl=file://${mnt_path}/AIX_Toolbox_73" >> $CONF_FILE
-    echo "enabled=1" >> $CONF_FILE
-    echo "gpgcheck=1" >> $CONF_FILE
-    echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox" >> $CONF_FILE
-    echo "" >> $CONF_FILE
+    {
+    echo "[Local_AIX_Toolbox_73]"
+    echo "name=Local AIX 7.3 specific repository"
+    echo "baseurl=file://${mnt_path}/AIX_Toolbox_73"
+    echo "enabled=1"
+    echo "gpgcheck=1"
+    echo "gpgkey=file:///opt/freeware/etc/dnf/RPM-GPG-KEY-IBM-AIX-Toolbox"
+    echo ""
+    } >> $CONF_FILE
 else
     echo "Failed to add AIX local version specific repository."
 fi


### PR DESCRIPTION
ERROR: Found 1 shebang issue(s) which need to be resolved:
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:1:1: unexpected non-module shebang: b'#!/bin/ksh'
See documentation for help: https://docs.ansible.com/ansible-core/2.16/dev_guide/testing/sanity/shebang.html
Running sanity test "shellcheck"
ERROR: Found 49 shellcheck issue(s) which need to be resolved:
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:14:5: SC2034: RPM_CMD appears unused. Verify use (or export if used externally).
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:26:7: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:28:12: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:29:12: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:30:12: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:98:11: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:99:11: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:100:1: SC2034: f3 appears unused. Verify use (or export if used externally).
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:100:11: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:101:1: SC2034: f4 appears unused. Verify use (or export if used externally).
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:101:11: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:107:7: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:109:14: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:110:14: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:111:14: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:112:14: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:126:26: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:127:14: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:135:26: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:136:14: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:147:6: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:147:37: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:150:8: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:150:39: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:153:8: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:153:39: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:161:22: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:162:10: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:172:11: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:173:19: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:174:9: SC2006: Use $(...) notation instead of legacy backticked `...`.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:174:9: SC2116: Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:174:24: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:175:4: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:183:17: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:183:52: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:184:10: SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:192:17: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:192:55: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:193:10: SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:203:10: SC2028: echo may not expand escape sequences. Use printf.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:206:10: SC2028: echo may not expand escape sequences. Use printf.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:210:19: SC2154: arg is referenced but not assigned.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:215:12: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:220:12: SC2086: Double quote to prevent globbing and word splitting.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:233:1: SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:264:5: SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:273:5: SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects.
ERROR: roles/power_aix_bootstrap/files/dnf_local.sh:282:5: SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects.
See documentation for help: https://docs.ansible.com/ansible-core/2.16/dev_guide/testing/sanity/shellcheck.html
Running sanity test "symlinks"
Running sanity test "use-argspec-type-path"
Running sanity test "use-compat-six"
Running sanity test "yamllint"
ERROR: Found 1 yamllint issue(s) which need to be resolved:
ERROR: playbooks/demo_hdcrypt_auth.yml:106:1: empty-lines: too many blank lines (1 > 0)
See documentation for help: https://docs.ansible.com/ansible-core/2.16/dev_guide/testing/sanity/yamllint.html
ERROR: The 3 sanity test(s) listed below (out of 35) failed. See error output above for details.
shebang
shellcheck
yamllint