### PR TITLE
Fixed reboot action - connection reset issue

### DIFF
--- a/plugins/action/reboot.py
+++ b/plugins/action/reboot.py
@@ -28,7 +28,7 @@ class ActionModule(ActionBase):
     TRANSFERS_FILES = False
     _VALID_ARGS = frozenset(('post_reboot_delay', 'pre_reboot_delay', 'test_command', 'reboot_timeout'))
 
-    boot_time_command = 'who -b'
+    boot_time_command = 'whoami'
     reboot_command = 'shutdown -r'
     DEFAULT_PRE_REBOOT_DELAY = 0
     DEFAULT_POST_REBOOT_DELAY = 0
@@ -112,6 +112,13 @@ class ActionModule(ActionBase):
                         self._connection.reset()
                     except AttributeError:
                         pass
+                    # Added sleep so that the connection gets time to reset
+                    time.sleep(10)
+                else:
+                    raise
+            else:
+                # Added sleep so that the connection gets time to reset
+                time.sleep(5)
         raise TimedOutException("Connection reset failed while validating the reboot.")
 
     def run(self, tmp=None, task_vars=None):


### PR DESCRIPTION
Fixes issue #679 and #666

The issue was arising because module was trying to trigger the validation command without giving proper time for resetting connection. Adding sleep at the required stage resolves the issue.
Also, changed the validation command from `who -b` to `whoami`


Output:
```
PLAY [Reboot the machine] ********************************************************************************************************************************

TASK [Reboot the machine] ********************************************************************************************************************************
changed: [root@XXXXXXXXXXXX]

TASK [ansible.builtin.debug] *****************************************************************************************************************************
ok: [root@ XXXXXXXXXXXX] => {
    "reboot_result": {
        "changed": true,
        "elapsed": "391 sec",
        "failed": false,
        "msg": "System has been rebooted SUCCESSFULLY",
        "rebooted": true
    }
}

PLAY RECAP ***********************************************************************************************************************************************
root@ XXXXXXXXXXXX : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```