### PR TITLE
Fixed nim standalone client creation

### DIFF
--- a/plugins/modules/nim_resource.py
+++ b/plugins/modules/nim_resource.py
@@ -316,7 +316,7 @@ def res_create(nim_cmd, module):
     attributes = module.params['attributes']
 
     if object_type:
-        if object_type == "res_group":
+        if object_type == "res_group" or object_type == "standalone":
             cmd = nim_cmd + ' -o define '
         else:
             cmd = nim_cmd + ' -a server=master -o define '


### PR DESCRIPTION
Fix for #683. Removes the "-a server=master" from NIM command when object_type is standalone.