### PR TITLE
Added system os version in emgr module's output

### DIFF
--- a/plugins/modules/emgr.py
+++ b/plugins/modules/emgr.py
@@ -775,7 +775,7 @@ def main():
             results['changed'] = True
         elif action == 'list' and not module.params['preview'] and not module.check_mode and (rc == 0):
             results['ifix_details'] = parse_ifix_details(stdout)
-        
+
         # Adding system oslevel to output
         rc, stdout, stderr = module.run_command('usr/bin/oslevel -s')
 
@@ -783,7 +783,7 @@ def main():
             results['msg'] = "Failed to retrieve the oslevel from the system. Check stderr for more details."
             results['stderr'] = stderr
             module.fail_json(**results)
-        
+
         results['oslevel'] = stdout.rstrip()
 
     else:

--- a/plugins/modules/emgr.py
+++ b/plugins/modules/emgr.py
@@ -474,6 +474,7 @@ def main():
         msg='',
         stdout='',
         stderr='',
+        oslevel = '',
         ifix_details=[],
         reboot_required=False,
     )
@@ -774,6 +775,17 @@ def main():
             results['changed'] = True
         elif action == 'list' and not module.params['preview'] and not module.check_mode and (rc == 0):
             results['ifix_details'] = parse_ifix_details(stdout)
+        
+        # Adding system oslevel to output
+        rc, stdout, stderr = module.run_command('usr/bin/oslevel -s')
+
+        if rc:
+            results['msg'] = "Failed to retrieve the oslevel from the system. Check stderr for more details."
+            results['stderr'] = stderr
+            module.fail_json(**results)
+        
+        results['oslevel'] = stdout.rstrip()
+
     else:
         results['msg'] = f'Command {cmd} has no preview mode, execution skipped.'
         results['stdout'] = 'No stdout as execution has been skipped.'

--- a/plugins/modules/emgr.py
+++ b/plugins/modules/emgr.py
@@ -474,7 +474,7 @@ def main():
         msg='',
         stdout='',
         stderr='',
-        oslevel = '',
+        oslevel='',
         ifix_details=[],
         reboot_required=False,
     )


### PR DESCRIPTION
Will add system os version to output of emgr module.
Verbose output will look like this (with additional details):

```
    "msg": "Command ['emgr', '-l'] successful.",
    "oslevel": "7300-02-00-0000",
    "reboot_required": false,
```