### PR TITLE
Add new entstat modules

### DIFF
--- a/playbooks/demo_entstat.yml
+++ b/playbooks/demo_entstat.yml
@@ -1,0 +1,56 @@
+---
+- name: Run entstat command with various options on AIX
+  hosts: "{{ host_name }}"
+  gather_facts: false
+  vars:
+    host_name: usertest
+    user_name: aixguest
+    password_val: Password
+    concat_v1: 'True'
+    output_dir: "/tmp/entstatdata"
+
+  tasks:
+
+    - name: Run entstat with default stats on ent0
+      ibm.power_aix.entstat:
+        device_name: ent0
+        reset_stats: true
+        recorded_output: "{{ output_dir }}/entstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run entstat with device-specific statistics
+      ibm.power_aix.entstat:
+        device_name: ent0
+        device_statistics: true
+        recorded_output: "{{ output_dir }}/entstat_output1.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run entstat with reset statistics
+      ibm.power_aix.entstat:
+        device_name: ent0
+        reset_stats: true
+        recorded_output: "{{ output_dir }}/entstat_output2.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run entstat with debug trace option
+      ibm.power_aix.entstat:
+        device_name: ent0
+        debug_trace: true
+        recorded_output: "{{ output_dir }}/entstat_output3.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run entstat with device-specific stats and reset
+      ibm.power_aix.entstat:
+        device_name: ent0
+        device_statistics: true
+        reset_stats: true
+        recorded_output: "{{ output_dir }}/entstat_output4.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run entstat with device-specific stats and debug trace
+      ibm.power_aix.entstat:
+        device_name: ent0
+        device_statistics: true
+        debug_trace: true
+        recorded_output: "{{ output_dir }}/entstat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"

--- a/plugins/modules/entstat.py
+++ b/plugins/modules/entstat.py
@@ -12,7 +12,7 @@ module: entstat
 author:
   - AIX Development Team (@vivekpandeyibm)
 short_description: Collects Ethernet device statistics using the entstat command on AIX
-version_added: "2.1.0"
+version_added: "2.2.0"
 description:
   - This module allows you to gather statistics from Ethernet devices using the AIX entstat command.
   - Supports device-generic statistics, device-specific reporting, reset, and debug trace toggle.

--- a/plugins/modules/entstat.py
+++ b/plugins/modules/entstat.py
@@ -1,0 +1,183 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025- IBM, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+DOCUMENTATION = r'''
+---
+module: entstat
+short_description: Collects Ethernet device statistics using the entstat command on AIX
+version_added: "2.1.0"
+description:
+  - This module allows you to gather statistics from Ethernet devices using the AIX entstat command.
+  - Supports device-generic statistics, device-specific reporting, reset, and debug trace toggle.
+options:
+  device_name:
+    description:
+      - Name of the Ethernet device (for example, ent0).
+    type: str
+    required: true
+  device_statistics:
+    description:
+      - Displays all statistics, including device-specific statistics (-d).
+    type: bool
+    default: false
+  reset_stats:
+    description:
+      - Resets all statistics back to initial values (-r).
+      - Only privileged users can issue this flag.
+    type: bool
+    default: false
+  debug_trace:
+    description:
+      - Toggles debug trace in some device drivers (-t).
+    type: bool
+    default: false
+  recorded_output:
+    description:
+      - Path to file where command output should be written.
+    type: str
+  concatenated_output:
+    description:
+      - Controls whether the output is appended to the file or overwrites it.
+    type: bool
+    required: true
+notes:
+  - You can refer to the IBM documentation for additional information on the entstat command at
+    U(https://www.ibm.com/docs/en/aix/7.3.0?topic=e-entstat-command).
+'''
+
+EXAMPLES = r'''
+- name: Run entstat on ent0 with generic stats
+  ibm.power_aix.entstat:
+    device_name: ent0
+
+- name: Run entstat with device-specific stats on ent1
+  ibm.power_aix.entstat:
+    device_name: ent1
+    device_statistics: true
+
+- name: Run entstat with reset stats
+  ibm.power_aix.entstat:
+    device_name: ent0
+    reset_stats: true
+
+- name: Run entstat with debug trace enabled
+  ibm.power_aix.entstat:
+    device_name: ent0
+    debug_trace: true
+'''
+
+RETURN = r'''
+msg:
+    description: Execution message indicating success or failure.
+    returned: always
+    type: str
+    sample: 'entstat executed successfully with given options.'
+cmd:
+    description: Full entstat command executed.
+    returned: always
+    type: str
+    sample: 'entstat -d ent0'
+rc:
+    description: Return code from entstat command.
+    returned: always
+    type: int
+stdout:
+    description: Standard output from entstat command.
+    returned: always
+    type: str
+stderr:
+    description: Error output from entstat command (if any).
+    returned: on failure
+    type: str
+'''
+
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import os
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+
+def build_entstat_command(module):
+    '''
+    Build the entstat command with specified options
+    arguments:
+        module  (dict): The Ansible module
+    Returns:
+        cmd - A successfully created entstat command
+    '''
+    cmd = ['entstat']
+
+    if module.params['device_statistics']:
+        cmd.append('-d')
+    if module.params['reset_stats']:
+        cmd.append('-r')
+    if module.params['debug_trace']:
+        cmd.append('-t')
+
+    cmd.append(module.params['device_name'])
+    return cmd
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            device_name=dict(type='str', required=True),
+            device_statistics=dict(type='bool', default=False),
+            reset_stats=dict(type='bool', default=False),
+            debug_trace=dict(type='bool', default=False),
+            recorded_output=dict(type='str'),
+            concatenated_output=dict(type='bool', required=True),
+        ),
+        supports_check_mode=False
+    )
+
+    result = dict(changed=False, msg='', cmd='', rc=0, stdout='', stderr='')
+
+    cmd = build_entstat_command(module)
+
+    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
+
+    result = {
+        'changed': False,
+        'cmd': cmd,
+        'rc': rc,
+        'stdout': stdout,
+        'stderr': stderr
+    }
+
+    if rc != 0:
+        result['msg'] = f"entstat command failed with command  {cmd}"
+        module.fail_json(**result)
+    else:
+        if module.params['recorded_output']:
+            output_file = module.params['recorded_output']
+            output_dir = os.path.dirname(output_file)
+            if output_dir and not os.path.exists(output_dir):
+                try:
+                    os.makedirs(output_dir, exist_ok=True)
+                except Exception as e:
+                    module.fail_json(msg=f"Failed to create directory {output_dir}: {str(e)}", **result)
+            mode = 'a' if module.params['concatenated_output'] else 'w'
+            with open(output_file, mode) as f:
+                f.write(stdout + '\n')
+            result['changed'] = True
+            result['msg'] = f"entstat executed successfully with command '{cmd}' and output written to {output_file}"
+        else:
+            result['msg'] = f"entstat executed successfully with command '{cmd}'"
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/entstat.py
+++ b/plugins/modules/entstat.py
@@ -9,6 +9,8 @@ from __future__ import absolute_import, division, print_function
 DOCUMENTATION = r'''
 ---
 module: entstat
+author:
+  - AIX Development Team (@vivekpandeyibm)
 short_description: Collects Ethernet device statistics using the entstat command on AIX
 version_added: "2.1.0"
 description:

--- a/tests/unit/plugins/modules/test_entstat.py
+++ b/tests/unit/plugins/modules/test_entstat.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest import mock
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.power_aix.plugins.modules import entstat
+from .common.utils import fail_json, AnsibleFailJson
+
+
+class TestEntstatModule(unittest.TestCase):
+    def setUp(self):
+        self.module = mock.Mock(spec=AnsibleModule)
+        self.module.fail_json = fail_json
+        self.module.fail_json.side_effect = AnsibleFailJson
+
+        self.params = {
+            'device_name': 'ent0',
+            'device_statistics': False,
+            'reset_stats': False,
+            'debug_trace': False,
+            'recorded_output': "/tmp/entstatdata/entstat_output.txt",
+            'concatenated_output': True,
+        }
+        self.module.params = self.params
+
+    def test_default_command(self):
+        cmd = entstat.build_entstat_command(self.module)
+        self.assertEqual(cmd, ['entstat', 'ent0'])
+
+    def test_device_statistics(self):
+        self.module.params.update({'device_statistics': True})
+        cmd = entstat.build_entstat_command(self.module)
+        self.assertEqual(cmd, ['entstat', '-d', 'ent0'])
+
+    def test_reset_stats(self):
+        self.module.params.update({'reset_stats': True})
+        cmd = entstat.build_entstat_command(self.module)
+        self.assertEqual(cmd, ['entstat', '-r', 'ent0'])
+
+    def test_debug_trace(self):
+        self.module.params.update({'debug_trace': True})
+        cmd = entstat.build_entstat_command(self.module)
+        self.assertEqual(cmd, ['entstat', '-t', 'ent0'])
+
+    def test_all_flags_enabled(self):
+        self.module.params.update({
+            'device_statistics': True,
+            'reset_stats': True,
+            'debug_trace': True
+        })
+        cmd = entstat.build_entstat_command(self.module)
+        # Order matters, same as implementation
+        self.assertEqual(cmd, ['entstat', '-d', '-r', '-t', 'ent0'])
+
+    def test_output_file_handling(self):
+        # Just simulate with params; full IO tested in integration
+        self.module.params.update({'recorded_output': '/tmp/entstatdata/test_out.txt'})
+        self.module.params.update({'device_name': 'ent2'})
+        cmd = entstat.build_entstat_command(self.module)
+        self.assertIn('ent2', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1: New module entstat.py is added. The entstat command displays the statistics that are gathered by the specified Ethernet device driver.
2: New Playbook demo_entstat.yml is added 
3: New pytest test_entstat.py is added

Output:

```
PLAY [Run entstat command with various options on AIX] ***************************************************************************************************************************************************************

TASK [Run entstat with default stats on ent0] ************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxxxxxx]

TASK [Run entstat with device-specific statistics] *******************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxxxxxx]

TASK [Run entstat with reset statistics] *****************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxxxxxx]

TASK [Run entstat with debug trace option] ***************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxxxxxx]

TASK [Run entstat with device-specific stats and reset] **************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxxxxxx]

TASK [Run entstat with device-specific stats and debug trace] ********************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxxxxxx]

PLAY RECAP ***********************************************************************************************************************************************************************************************************
root@xxxxxxxxxxxxxxxxxxxxxxx : ok=6    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```
