### PR TITLE
Add new netstat modules

### DIFF
--- a/playbooks/demo_netstat.yml
+++ b/playbooks/demo_netstat.yml
@@ -1,0 +1,277 @@
+---
+- name: Netstat module full option tests
+  hosts: "{{ host_name }}"
+  gather_facts: false
+  vars:
+    host_name: integration
+    output_dir: "/tmp/netstatdata"
+    concat_v1: true
+
+  tasks:
+
+    - name: Run netstat with all sockets, socket options and numeric address
+      ibm.power_aix.netstat:
+        all_sockets_state: true
+        socket_options: true
+        numeric_network_address: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test1.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with routing table, protocol tcp and address family inet
+      ibm.power_aix.netstat:
+        routing_table: true
+        protocol: tcp
+        address_family: inet
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test2.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with ras artifacts tcp, ras file and suppress nonzero
+      ibm.power_aix.netstat:
+        ras_artifacts: tcp
+        ras_file: "{{ output_dir }}/tcp_ras.log"
+        ras_suppress_nonzero: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test3.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with domain sockets, memory stats and pcb address
+      ibm.power_aix.netstat:
+        domain_sockets: true
+        memory_stats: true
+        pcb_address: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test4.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with show route details, routing table and numeric address
+      ibm.power_aix.netstat:
+        show_route_details: true
+        routing_table: true
+        numeric_network_address: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test5.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with display interfaces, interface name ent0 and packet counts
+      ibm.power_aix.netstat:
+        display_configured_interfaces: true
+        interface_name: ent0
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test6.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with virtual interface and cache stats
+      ibm.power_aix.netstat:
+        virtual_interface_and_multicast: true
+        cache_stats: true
+        recorded_output: "{{ output_dir }}/test7.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with ras artifacts udp, ras file and interactive mode
+      ibm.power_aix.netstat:
+        ras_artifacts: udp
+        ras_file: "{{ output_dir }}/udp_ras.log"
+        interactive_mode: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test8.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with display adapter statistics, numeric and pcb address
+      ibm.power_aix.netstat:
+        display_adapter_statistics: true
+        numeric_network_address: true
+        pcb_address: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test9.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with memory stats, mbuf pool stats and protocol tcp
+      ibm.power_aix.netstat:
+        memory_stats: true
+        mbuf_pool_stats: true
+        protocol: tcp
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test11.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with virtual interface, routing table and packet counts
+      ibm.power_aix.netstat:
+        virtual_interface_and_multicast: true
+        packet_counts: true
+        recorded_output: "{{ output_dir }}/test12.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with ras artifacts tcp, ras file and protocol stats
+      ibm.power_aix.netstat:
+        ras_artifacts: tcp
+        ras_file: "{{ output_dir }}/tcp_ras2.log"
+        protocol_stats: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test13.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with all sockets, pcb address and address family unix
+      ibm.power_aix.netstat:
+        all_sockets_state: true
+        pcb_address: true
+        address_family: unix
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test14.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with concise protocol stats, domain sockets and pcb address
+      ibm.power_aix.netstat:
+        concise_protocol_stats: true
+        domain_sockets: true
+        pcb_address: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test15.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with clear interface stats, memory stats and numeric address
+      ibm.power_aix.netstat:
+        clear_stats: "i"
+        clear_stats: "m"
+        clear_stats: "s"
+        recorded_output: "{{ output_dir }}/test16.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with clear memory stats, domain sockets and address family inet
+      ibm.power_aix.netstat:
+        clear_stats: "m"
+        recorded_output: "{{ output_dir }}/test17.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with clear protocol stats, routing table and pcb address
+      ibm.power_aix.netstat:
+        clear_stats: "s"
+        recorded_output: "{{ output_dir }}/test18.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with display interfaces, data link stat and protocol tcp
+      ibm.power_aix.netstat:
+        display_configured_interfaces: true
+        protocol: tcp
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test19.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with ras artifacts udp, ras file and address family inet
+      ibm.power_aix.netstat:
+        ras_artifacts: udp
+        ras_file: "{{ output_dir }}/udp_ras2.log"
+        address_family: inet
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test20.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with protocol_stats and concise_protocol_stats
+      ibm.power_aix.netstat:
+        protocol_stats: true
+        concise_protocol_stats: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test21.txt"
+        concatenated_output: "{{ concat_v1 }}"
+      ignore_errors: true
+
+    - name: Run netstat with clear stats and routing table
+      ibm.power_aix.netstat:
+        clear_stats: "c"
+        recorded_output: "{{ output_dir }}/test22.txt"
+        concatenated_output: "{{ concat_v1 }}"
+      ignore_errors: true
+
+    - name: Run netstat with clear stats and ras artifacts
+      ibm.power_aix.netstat:
+        clear_stats: "s"
+        recorded_output: "{{ output_dir }}/test23.txt"
+        concatenated_output: "{{ concat_v1 }}"
+      ignore_errors: true
+
+    - name: Run netstat with all sockets and routing table together
+      ibm.power_aix.netstat:
+        all_sockets_state: true
+        routing_table: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test24.txt"
+        concatenated_output: "{{ concat_v1 }}"
+      ignore_errors: true
+
+    - name: Run netstat with clear stats and protocol stats
+      ibm.power_aix.netstat:
+        clear_stats: "s"
+        recorded_output: "{{ output_dir }}/test25.txt"
+        concatenated_output: "{{ concat_v1 }}"
+      ignore_errors: true
+
+    - name: Run netstat with clear stats and domain sockets
+      ibm.power_aix.netstat:
+        clear_stats: "m"
+        recorded_output: "{{ output_dir }}/test26.txt"
+        concatenated_output: "{{ concat_v1 }}"
+      ignore_errors: true
+
+    - name: Run netstat with clear stats and cache stats
+      ibm.power_aix.netstat:
+        clear_stats: "c"
+        recorded_output: "{{ output_dir }}/test29.txt"
+        concatenated_output: "{{ concat_v1 }}"
+      ignore_errors: true
+
+    - name: Run netstat with ras artifacts tcp, ras file, interactive and suppress nonzero
+      ibm.power_aix.netstat:
+        ras_artifacts: tcp
+        ras_file: "{{ output_dir }}/tcp_ras3.log"
+        interactive_mode: true
+        ras_suppress_nonzero: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test31.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with packet counts, memory stats and pcb address
+      ibm.power_aix.netstat:
+        memory_stats: true
+        pcb_address: true
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test32.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run netstat with concise protocol stats, memory stats and address family inet6
+      ibm.power_aix.netstat:
+        concise_protocol_stats: true
+        memory_stats: true
+        address_family: inet6
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test35.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    - name: Run netstat with concise protocol stats, memory stats and address family inet4
+      ibm.power_aix.netstat:
+        concise_protocol_stats: true
+        interactive_mode: true
+        memory_stats: true
+        address_family: inet
+        interval: 1
+        count: 2
+        recorded_output: "{{ output_dir }}/test35.txt"
+        concatenated_output: "{{ concat_v1 }}"

--- a/plugins/modules/netstat.py
+++ b/plugins/modules/netstat.py
@@ -1,0 +1,403 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025 IBM
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: netstat
+author:
+    - AIX Development Team (@vivekpandeyibm)
+short_description: Collect network statistics using netstat on AIX
+description:
+  - This module allows you to gather network statistics using the AIX netstat command.
+  - Supports all reporting flags, mutual exclusiveness, and output recording.
+version_added: "2.1.0"
+requirements:
+    - AIX >= 7.1
+options:
+  numeric_network_address:
+    description:
+      - Display network addresses as numbers (-n).
+      - When this flag is not specified, the netstat command interprets addresses where possible and displays them symbolically.
+      - This flag can be used with any of the display formats.
+    type: bool
+    default: False
+  pcb_address:
+    description:
+      - Shows the address of any protocol control blocks associated with the sockets (-A).
+      - This flag acts with the default display and is used for debugging purposes.
+    type: bool
+    default: False
+  all_sockets_state:
+    description:
+      - Show state of all sockets (-a).
+      - If this flag is not specified, sockets that are used by server processes that are not bound to an interface are not shown.
+    type: bool
+    default: False
+  socket_options:
+    description:
+      - Show detailed socket info with -a (-o).
+    type: bool
+    default: False
+  routing_table:
+    description:
+      - Show routing tables (-r).
+      - When used with the '-s' flag, the '-r' flag shows routing statistics
+    type: bool
+    default: False
+  show_route_details:
+    description:
+      - Show routing tables with costs including the user-configured and current costs of each route (-C).
+      - It also shows the weight and policy information associated with each route
+    type: bool
+    default: False
+  packet_counts:
+    description:
+      - Shows the number of packets received, transmitted, and dropped in the communications subsystem (-D).
+    type: bool
+    default: False
+  display_configured_interfaces:
+    description:
+      - Shows the state of all configured interfaces (-i).
+    type: bool
+    default: False
+  interface_name:
+    description:
+      - Shows the state of the configured interface specified by the 'interface_name' variable. (-I).
+    type: str
+  protocol:
+    description:
+      - Shows statistics about the value specified for the 'protocol' variable (-p).
+    type: str
+  memory_stats:
+    description:
+      - Shows statistics recorded by the memory management routines. (-m).
+    type: bool
+    default: False
+  mbuf_pool_stats:
+    description:
+      - Shows network memory's mbuf cluster pool statistics. (-M).
+    type: bool
+    default: False
+  protocol_stats:
+    description:
+      - Shows statistics for each protocol. (-s).
+    type: bool
+    default: False
+  concise_protocol_stats:
+    description:
+      - Displays all the non-zero protocol statistics and provides a concise display (-ss).
+    type: bool
+    default: False
+  domain_sockets:
+    description:
+      - Displays information about domain sockets. (-u).
+    type: bool
+    default: False
+  display_adapter_statistics:
+    description:
+      - Shows statistics for CDLI-based communications adapters. (-v).
+      - This flag causes the netstat command to run the statistics commands for the netstat, tokstat, and fddistat commands
+    type: bool
+    default: False
+  virtual_interface_and_multicast:
+    description:
+      - Shows Virtual Interface Table and Multicast Forwarding Cache information (-g).
+      - If used in conjunction with the '-s' flag, it will show the multicast routing information.
+    type: bool
+    default: False
+  ras_artifacts:
+    description:
+      - Displays all reliability, availability, and serviceability (RAS) artifacts for the specified protocol (-K).
+    type: str
+  ras_file:
+    description:
+      - Output file for RAS artifacts with '-K' (-F).
+    type: str
+  ras_suppress_nonzero:
+    description:
+      - Suppresses the printing of non-zero counter values when you use the -K flag to display the RAS artifacts for a specific protocol(-b).
+    type: bool
+    default: False
+  interactive_mode:
+    description:
+      - Starts the user interactive mode. (-w).
+    type: bool
+    default: False
+  clear_stats:
+    description:
+      - Zc	Clear network buffer cache statistics.
+      - Zi	Clear interface statistics.
+      - Zm	Clear network memory allocator statistics.
+      - Zs	Clear protocol statistics
+    type: str
+    choices: ["c", "i", "m", "s"]
+  address_family:
+    description:
+      - Limits reports of statistics or address control blocks to those items specified by the AddressFamily variable (-f).
+    type: str
+    choices: ["inet", "inet6", "unix"]
+  interval:
+    description:
+      - Specifies the interval (in seconds) between lparstat readings.
+      - Used to gather repeated samples over time.
+    type: int
+  count:
+    description:
+      - Number of reports to generate at the specified interval.
+      - Must be used together with the interval option.
+    type: int
+   recorded_output:
+    description:
+      - Folder path to command output in machine .
+    type: str
+  concatenated_output:
+    description:
+      - Controls whether the output of the vmstat command is appended to the output file or is overwrited.
+      - If set to true, output will be appended to the file.
+      - If set to false, the file will be overwritten with fresh output.
+    type: bool
+    required: true
+notes:
+  - You can refer to the IBM documentation for additional information on the lparstat command at
+    U(https://www.ibm.com/docs/en/aix/7.3.0?topic=l-netstat-command).
+'''
+
+EXAMPLES = r'''
+- name: Show all sockets
+  ibm.power_aix.netstat:
+    all_sockets_state: true
+
+- name: Show routing table with costs
+  ibm.power_aix.netstat:
+    routing_table: true
+
+- name: Show RAS artifacts for TCP to file
+  ibm.power_aix.netstat:
+    ras_artifacts: tcp
+    ras_file: /tmp/tcp_ras.log
+'''
+
+RETURN = r'''
+msg:
+    description: The execution message.
+    returned: always
+    type: str
+    sample: 'netstat executed  SUCCESSFULLY '
+rc:
+    description: The return code.
+    returned: If the command failed.
+    type: int
+stdout:
+    description: The standard output.
+    returned: If the command failed.
+    type: str
+stderr:
+    description: The standard error.
+    returned: If the command failed.
+    type: str
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import os
+
+
+def validate_mutual_exclusiveness(module):
+    """
+    Ensure valid combinations of netstat flags.
+    """
+    results = {}
+
+    if module.params['count'] is None:
+        for f in ['numeric_network_address', 'pcb_address', 'all_sockets_state', 'routing_table', 'show_route_details', 'display_configured_interfaces',
+                  'interface_name', 'memory_stats', 'mbuf_pool_stats', 'protocol_stats', 'concise_protocol_stats', 'domain_sockets',
+                  'display_adapter_statistics', 'address_family', 'protocol']:
+            if module.params[f]:
+                results['msg'] = f"' count ' is mandatory with '{f}' option."
+                module.fail_json(**results)
+    if module.params['count'] is not None:
+        for f in ['virtual_interface_and_multicast', 'cache_stats', 'packet_counts']:
+            if module.params[f]:
+                results['msg'] = f"' count ' cannot be combined with '{f}' option."
+                module.fail_json(**results)
+
+    # clear stats cannot combine with display flags
+    if module.params['clear_stats']:
+        disallowed = ['routing_table', 'show_route_details', 'cache_stats', 'packet_counts',
+                      'display_configured_interfaces', 'interface_name', 'protocol',
+                      'memory_stats', 'mbuf_pool_stats', 'protocol_stats',
+                      'concise_protocol_stats', 'domain_sockets',
+                      'display_adapter_statistics', 'virtual_interface_and_multicast',
+                      'numeric_network_address', 'pcb_address', 'all_sockets_state',
+                      'socket_options', 'ras_artifacts', 'ras_file', 'ras_suppress_nonzero',
+                      'interactive_mode', 'address_family', 'interval', 'count']
+        for d in disallowed:
+            if module.params[d]:
+                module.fail_json(msg=f"'-Z{module.params['clear_stats']}' cannot be combined with option '{d}'.")
+    # interval requires count
+    if module.params['interval'] and not module.params['count']:
+        module.fail_json(msg="When using 'interval', you must specify 'count'.")
+
+    # count requires interval
+    if module.params['count'] and not module.params['interval']:
+        module.fail_json(msg="The 'count' option must be used with 'interval'.")
+
+
+def build_netstat_command(module):
+    '''
+    Build the netstat command with specified options
+    arguments:
+        module  (dict): The Ansible module
+    Returns:
+        cmd - A successfully created netstat command
+    '''
+
+    cmd = ['/bin/netstat']
+
+    if module.params['numeric_network_address']:
+        cmd.append('-n')
+    if module.params['pcb_address']:
+        cmd.append('-A')
+    if module.params['all_sockets_state']:
+        cmd.append('-a')
+        if module.params['socket_options']:
+            cmd.append('-o')
+    if module.params['display_configured_interfaces']:
+        cmd.append('-i')
+        if module.params['interface_name']:
+            cmd.extend(['-I', module.params['interface_name']])
+    elif module.params['show_route_details']:
+        cmd.append('-C')
+    elif module.params['routing_table']:
+        cmd.append('-r')
+
+    # To Display the Contents of a Network Data Structure
+    if module.params['memory_stats']:
+        cmd.append('-m')
+    elif module.params['mbuf_pool_stats']:
+        cmd.append('-M')
+    elif module.params['display_adapter_statistics']:
+        cmd.append('-v')
+    elif module.params['domain_sockets']:
+        cmd.append('-u')
+
+    if module.params['concise_protocol_stats']:
+        cmd.append('-ss')
+    elif module.params['protocol_stats']:
+        cmd.append('-s')
+
+    # To Display the Virtual Interface Table and Multicast Forwarding Cache
+    if module.params['virtual_interface_and_multicast']:
+        cmd.append('-g')
+
+    # To Display the Network Buffer Cache Statistics
+    if module.params['cache_stats']:
+        cmd.append('-c')
+
+    # To Display the Packet Counts Throughout the Communications Subsystem
+    if module.params['packet_counts']:
+        cmd.append('-D')
+
+    # To display artifacts for a specific protocol
+    if module.params['ras_artifacts']:
+        cmd.extend(['-K', module.params['ras_artifacts']])
+        if module.params['ras_file']:
+            if os.path.exists(module.params['ras_file']):
+                os.remove(module.params['ras_file'])
+            cmd.extend(['-F', module.params['ras_file']])
+        if module.params['ras_suppress_nonzero']:
+            cmd.append('-b')
+        if module.params['interactive_mode']:
+            cmd.append('-w')
+    # To Clear the Associated Statistics
+    if module.params['clear_stats']:
+        cmd.append(f"-Z{module.params['clear_stats']}")
+
+    # Independent modifiers (can stack with others)
+
+    if module.params['address_family']:
+        cmd.extend(['-f', module.params['address_family']])
+    if module.params['protocol']:
+        cmd.extend(['-p', module.params['protocol']])
+    # Interval/count logic
+    if module.params['interval'] is not None:
+        cmd.append(str(module.params['interval']))
+        if module.params['count'] is not None:
+            count_value = int(module.params['count']) + 2
+            cmd.extend(['| head -n ', str(count_value)])
+    return cmd
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            numeric_network_address=dict(type='bool', default=False),
+            pcb_address=dict(type='bool', default=False),
+            all_sockets_state=dict(type='bool', default=False),
+            socket_options=dict(type='bool', default=False),
+            routing_table=dict(type='bool', default=False),
+            show_route_details=dict(type='bool', default=False),
+            packet_counts=dict(type='bool', default=False),
+            display_configured_interfaces=dict(type='bool', default=False),
+            interface_name=dict(type='str'),
+            protocol=dict(type='str'),
+            memory_stats=dict(type='bool', default=False),
+            mbuf_pool_stats=dict(type='bool', default=False),
+            protocol_stats=dict(type='bool', default=False),
+            concise_protocol_stats=dict(type='bool', default=False),
+            domain_sockets=dict(type='bool', default=False),
+            display_adapter_statistics=dict(type='bool', default=False),
+            virtual_interface_and_multicast=dict(type='bool', default=False),
+            ras_artifacts=dict(type='str'),
+            ras_file=dict(type='str'),
+            ras_suppress_nonzero=dict(type='bool', default=False),
+            interactive_mode=dict(type='bool', default=False),
+            clear_stats=dict(type='str', choices=["c", "i", "m", "s"]),
+            address_family=dict(type='str', choices=["inet", "inet6", "unix"]),
+            interval=dict(type='int'),
+            count=dict(type='int'),
+            recorded_output=dict(type='str'),
+            concatenated_output=dict(type='bool', required=True),
+            cache_stats=dict(type='bool', default=False),
+        ),
+        supports_check_mode=False
+    )
+
+    result = dict(changed=False, cmd='', rc=0, stdout='', stderr='', msg='')
+
+    validate_mutual_exclusiveness(module)
+    cmd = build_netstat_command(module)
+    result['cmd'] = " ".join(cmd)
+    new_cmd = " ".join(cmd)
+    rc, stdout, stderr = module.run_command(new_cmd, use_unsafe_shell=True)
+    result.update({'rc': rc, 'stdout': stdout, 'stderr': stderr})
+
+    if rc != 0:
+        result['msg'] = f"netstat failed with {cmd}"
+        module.fail_json(**result)
+    else:
+        if module.params['recorded_output']:
+            output_file = module.params['recorded_output']
+            output_dir = os.path.dirname(output_file)
+            if output_dir and not os.path.exists(output_dir):
+                try:
+                    os.makedirs(output_dir, exist_ok=True)
+                except Exception as e:
+                    module.fail_json(msg=f"Failed to create directory {output_dir}: {str(e)}", **result)
+            mode = 'a' if module.params['concatenated_output'] else 'w'
+            with open(module.params['recorded_output'], mode) as f:
+                f.write(stdout + '\n')
+            result['changed'] = True
+            result['msg'] += f"netstat executed successfully with command '{cmd}' and Output written to {output_file}"
+        else:
+            result['msg'] += f"netstat executed successfully with command '{cmd}'"
+        module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/netstat.py
+++ b/plugins/modules/netstat.py
@@ -11,160 +11,185 @@ DOCUMENTATION = r'''
 ---
 module: netstat
 author:
-    - AIX Development Team (@vivekpandeyibm)
-short_description: Collect network statistics using netstat on AIX
+  - AIX Development Team (@vivekpandeyibm)
+short_description: Collect network statistics using the AIX netstat command
 description:
-  - This module allows you to gather network statistics using the AIX netstat command.
-  - Supports all reporting flags, mutual exclusiveness, and output recording.
-version_added: "2.1.0"
+  - This module gathers detailed network statistics using the AIX C(netstat) command.
+  - Supports all reporting flags, mutual exclusiveness validation, repeated sampling,
+    and recording the command output to a file.
+version_added: "2.2.0"
 requirements:
-    - AIX >= 7.1
+  - AIX >= 7.1
+
 options:
   numeric_network_address:
     description:
-      - Display network addresses as numbers (-n).
-      - When this flag is not specified, the netstat command interprets addresses where possible and displays them symbolically.
-      - This flag can be used with any of the display formats.
+      - Display network addresses numerically using C(-n).
+      - When omitted, symbolic hostnames may appear.
     type: bool
-    default: False
+    default: false
+
   pcb_address:
     description:
-      - Shows the address of any protocol control blocks associated with the sockets (-A).
-      - This flag acts with the default display and is used for debugging purposes.
+      - Show protocol control block (PCB) addresses using C(-A).
     type: bool
-    default: False
+    default: false
+
   all_sockets_state:
     description:
-      - Show state of all sockets (-a).
-      - If this flag is not specified, sockets that are used by server processes that are not bound to an interface are not shown.
+      - Display the state of all sockets using C(-a).
     type: bool
-    default: False
+    default: false
+
   socket_options:
     description:
-      - Show detailed socket info with -a (-o).
+      - Show detailed socket options along with C(-a) using C(-o).
     type: bool
-    default: False
+    default: false
+
   routing_table:
     description:
-      - Show routing tables (-r).
-      - When used with the '-s' flag, the '-r' flag shows routing statistics
+      - Display routing tables using C(-r).
     type: bool
-    default: False
+    default: false
+
   show_route_details:
     description:
-      - Show routing tables with costs including the user-configured and current costs of each route (-C).
-      - It also shows the weight and policy information associated with each route
+      - Display routing details including metrics and policy information using C(-C).
     type: bool
-    default: False
+    default: false
+
   packet_counts:
     description:
-      - Shows the number of packets received, transmitted, and dropped in the communications subsystem (-D).
+      - Show communications subsystem packet counts using C(-D).
     type: bool
-    default: False
+    default: false
+
   display_configured_interfaces:
     description:
-      - Shows the state of all configured interfaces (-i).
+      - Display all configured interfaces using C(-i).
     type: bool
-    default: False
+    default: false
+
   interface_name:
     description:
-      - Shows the state of the configured interface specified by the 'interface_name' variable. (-I).
+      - Display information for a specific interface using C(-I <interface>).
     type: str
+
   protocol:
     description:
-      - Shows statistics about the value specified for the 'protocol' variable (-p).
+      - Display statistics for the given protocol using C(-p).
     type: str
+
   memory_stats:
     description:
-      - Shows statistics recorded by the memory management routines. (-m).
+      - Display memory management statistics using C(-m).
     type: bool
-    default: False
+    default: false
+
   mbuf_pool_stats:
     description:
-      - Shows network memory's mbuf cluster pool statistics. (-M).
+      - Display mbuf cluster pool statistics using C(-M).
     type: bool
-    default: False
+    default: false
+
   protocol_stats:
     description:
-      - Shows statistics for each protocol. (-s).
+      - Display protocol statistics using C(-s).
     type: bool
-    default: False
+    default: false
+
   concise_protocol_stats:
     description:
-      - Displays all the non-zero protocol statistics and provides a concise display (-ss).
+      - Display only non-zero protocol statistics using C(-ss).
     type: bool
-    default: False
+    default: false
+
   domain_sockets:
     description:
-      - Displays information about domain sockets. (-u).
+      - Display information about domain sockets using C(-u).
     type: bool
-    default: False
+    default: false
+
   display_adapter_statistics:
     description:
-      - Shows statistics for CDLI-based communications adapters. (-v).
-      - This flag causes the netstat command to run the statistics commands for the netstat, tokstat, and fddistat commands
+      - Display adapter statistics for CDLI adapters using C(-v).
     type: bool
-    default: False
+    default: false
+
   virtual_interface_and_multicast:
     description:
-      - Shows Virtual Interface Table and Multicast Forwarding Cache information (-g).
-      - If used in conjunction with the '-s' flag, it will show the multicast routing information.
+      - Display virtual interface table and multicast forwarding cache using C(-g).
     type: bool
-    default: False
+    default: false
+
   ras_artifacts:
     description:
-      - Displays all reliability, availability, and serviceability (RAS) artifacts for the specified protocol (-K).
+      - Display reliability, availability, and serviceability (RAS) artifacts using C(-K <protocol>).
     type: str
+
   ras_file:
     description:
-      - Output file for RAS artifacts with '-K' (-F).
+      - File path to store RAS output when using C(-F).
     type: str
+
   ras_suppress_nonzero:
     description:
-      - Suppresses the printing of non-zero counter values when you use the -K flag to display the RAS artifacts for a specific protocol(-b).
+      - Suppress non-zero counters in RAS output using C(-b).
     type: bool
-    default: False
+    default: false
+
   interactive_mode:
     description:
-      - Starts the user interactive mode. (-w).
+      - Start interactive mode using C(-w).
     type: bool
-    default: False
+    default: false
+
   clear_stats:
     description:
-      - Zc	Clear network buffer cache statistics.
-      - Zi	Clear interface statistics.
-      - Zm	Clear network memory allocator statistics.
-      - Zs	Clear protocol statistics
+      - Clear statistics using C(-Z).
+      - C(c) clears network buffer statistics.
+      - C(i) clears interface statistics.
+      - C(m) clears memory allocator statistics.
+      - C(s) clears protocol statistics.
     type: str
     choices: ["c", "i", "m", "s"]
+
   address_family:
     description:
-      - Limits reports of statistics or address control blocks to those items specified by the AddressFamily variable (-f).
+      - Limit reports to a specific address family using C(-f).
     type: str
     choices: ["inet", "inet6", "unix"]
+
   interval:
     description:
-      - Specifies the interval (in seconds) between lparstat readings.
-      - Used to gather repeated samples over time.
+      - Time in seconds between repeated netstat samples.
     type: int
+
   count:
     description:
-      - Number of reports to generate at the specified interval.
-      - Must be used together with the interval option.
+      - Number of samples to collect along with interval.
     type: int
-   recorded_output:
+
+  recorded_output:
     description:
-      - Folder path to command output in machine .
+      - File path to record command output.
     type: str
+
   concatenated_output:
     description:
-      - Controls whether the output of the vmstat command is appended to the output file or is overwrited.
-      - If set to true, output will be appended to the file.
-      - If set to false, the file will be overwritten with fresh output.
+      - If true, append output to file; if false, overwrite file.
     type: bool
     required: true
+
+  cache_stats:
+    description:
+      - Display network buffer cache statistics using C(-c).
+    type: bool
+    default: false
+
 notes:
-  - You can refer to the IBM documentation for additional information on the lparstat command at
+  - You can refer to the IBM documentation for additional information on the netstat command at
     U(https://www.ibm.com/docs/en/aix/7.3.0?topic=l-netstat-command).
 '''
 

--- a/plugins/modules/netstat.py
+++ b/plugins/modules/netstat.py
@@ -413,7 +413,8 @@ def main():
                 try:
                     os.makedirs(output_dir, exist_ok=True)
                 except Exception as e:
-                    module.fail_json(msg=f"Failed to create directory {output_dir}: {str(e)}", **result)
+                    result['msg'] = f"Failed to create directory {output_dir}: {str(e)}"
+                    module.fail_json(**result)
             mode = 'a' if module.params['concatenated_output'] else 'w'
             with open(module.params['recorded_output'], mode) as f:
                 f.write(stdout + '\n')

--- a/tests/unit/plugins/modules/test_netstat.py
+++ b/tests/unit/plugins/modules/test_netstat.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest import mock
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.power_aix.plugins.modules import netstat
+from .common.utils import fail_json, AnsibleFailJson
+
+
+class TestNetstatModule(unittest.TestCase):
+
+    def setUp(self):
+        self.module = mock.Mock(spec=AnsibleModule)
+        self.module.fail_json = fail_json
+        self.module.fail_json.side_effect = AnsibleFailJson
+        self.params = {
+            'numeric_network_address': False,
+            'pcb_address': False,
+            'all_sockets_state': False,
+            'socket_options': False,
+            'routing_table': False,
+            'show_route_details': False,
+            'packet_counts': False,
+            'display_configured_interfaces': False,
+            'interface_name': None,
+            'protocol': None,
+            'wpar': None,
+            'memory_stats': False,
+            'mbuf_pool_stats': False,
+            'protocol_stats': False,
+            'concise_protocol_stats': False,
+            'domain_sockets': False,
+            'display_adapter_statistics': False,
+            'virtual_interface_and_multicast': False,
+            'ras_artifacts': None,
+            'ras_file': None,
+            'ras_suppress_nonzero': False,
+            'interactive_mode': False,
+            'clear_stats': None,
+            'address_family': None,
+            'interval': None,
+            'count': None,
+            'recorded_output': None,
+            'concatenated_output': True,
+            'cache_stats': False,
+        }
+        self.module.params = self.params.copy()
+
+    def test_default_command(self):
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat'])
+
+    def test_numeric_flag(self):
+        self.module.params.update({'numeric_network_address': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-n'])
+
+    def test_pcb_flag(self):
+        self.module.params.update({'pcb_address': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-A'])
+
+    def test_all_sockets(self):
+        self.module.params.update({'all_sockets_state': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-a'])
+
+    def test_socket_options_with_all_sockets(self):
+        self.module.params.update({'all_sockets_state': True, 'socket_options': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-a', '-o'])
+
+    def test_routing_table(self):
+        self.module.params.update({'routing_table': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-r'])
+
+    def test_show_route_details(self):
+        self.module.params.update({'show_route_details': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-C'])
+
+    def test_packet_counts(self):
+        self.module.params.update({'packet_counts': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-D'])
+
+    def test_display_interfaces(self):
+        self.module.params.update({'display_configured_interfaces': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-i'])
+
+    def test_interface_name(self):
+        self.module.params.update({'display_configured_interfaces': True, 'interface_name': 'ent0'})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-i', '-I', 'ent0'])
+
+    def test_protocol(self):
+        self.module.params.update({'protocol': 'tcp'})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-p', 'tcp'])
+
+    def test_memory_stats(self):
+        self.module.params.update({'memory_stats': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-m'])
+
+    def test_mbuf_pool_stats(self):
+        self.module.params.update({'mbuf_pool_stats': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-M'])
+
+    def test_protocol_stats(self):
+        self.module.params.update({'protocol_stats': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-s'])
+
+    def test_concise_protocol_stats(self):
+        self.module.params.update({'concise_protocol_stats': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-ss'])
+
+    def test_domain_sockets(self):
+        self.module.params.update({'domain_sockets': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-u'])
+
+    def test_display_adapter_statistics(self):
+        self.module.params.update({'display_adapter_statistics': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-v'])
+
+    def test_virtual_interface_and_multicast(self):
+        self.module.params.update({'virtual_interface_and_multicast': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-g'])
+
+    def test_cache_stats(self):
+        self.module.params.update({'cache_stats': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-c'])
+
+    def test_ras_artifacts(self):
+        self.module.params.update({'ras_artifacts': 'tcp'})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-K', 'tcp'])
+
+    def test_ras_artifacts_with_file(self):
+        self.module.params.update({'ras_artifacts': 'tcp', 'ras_file': '/tmp/tcp_ras.log'})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-K', 'tcp', '-F', '/tmp/tcp_ras.log'])
+
+    def test_ras_artifacts_with_nonzero_and_interactive(self):
+        self.module.params.update({'ras_artifacts': 'udp', 'ras_suppress_nonzero': True, 'interactive_mode': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-K', 'udp', '-b', '-w'])
+
+    def test_clear_stats_s(self):
+        self.module.params.update({'clear_stats': 's'})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-Zs'])
+
+    def test_clear_stats_c(self):
+        self.module.params.update({'clear_stats': 'c'})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-Zc'])
+
+    def test_address_family_inet6(self):
+        self.module.params.update({'address_family': 'inet6'})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-f', 'inet6'])
+
+    def test_interval_and_count(self):
+        self.module.params.update({'interval': 2, 'count': 3})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '2', '| head -n ', '5'])
+
+    def test_numeric_pcb_protocol_combo(self):
+        self.module.params.update({'numeric_network_address': True, 'pcb_address': True, 'protocol': 'udp'})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-n', '-A', '-p', 'udp'])
+
+    def test_interface_and_family_combo(self):
+        self.module.params.update({'display_configured_interfaces': True, 'interface_name': 'en1', 'address_family': 'inet'})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-i', '-I', 'en1', '-f', 'inet'])
+
+    def test_multicast_and_packet_counts_combo(self):
+        self.module.params.update({'virtual_interface_and_multicast': True, 'packet_counts': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-g', '-D'])
+
+    def test_all_sockets_and_memory_combo(self):
+        self.module.params.update({'all_sockets_state': True, 'memory_stats': True})
+        cmd = netstat.build_netstat_command(self.module)
+        self.assertEqual(cmd, ['/bin/netstat', '-a', '-m'])
+
+    def test_protocol_stats_and_concise_protocol_stats_invalid(self):
+        self.module.params.update({'protocol_stats': True, 'concise_protocol_stats': True})
+        with self.assertRaises(AnsibleFailJson):
+            netstat.validate_mutual_exclusiveness(self.module)
+
+    def test_clear_stats_with_routing_table_invalid(self):
+        self.module.params.update({'clear_stats': 'c', 'routing_table': True})
+        with self.assertRaises(AnsibleFailJson):
+            netstat.validate_mutual_exclusiveness(self.module)
+
+    def test_interval_without_count_invalid(self):
+        self.module.params.update({'interval': 2})
+        with self.assertRaises(AnsibleFailJson):
+            netstat.validate_mutual_exclusiveness(self.module)
+
+    def test_count_without_interval_invalid(self):
+        self.module.params.update({'count': 2})
+        with self.assertRaises(AnsibleFailJson):
+            netstat.validate_mutual_exclusiveness(self.module)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1: New module netstat.py is added. The netstat command to display Active Sockets for Each Protocol or Routing Table Information
2: New Playbook demo_netstat.yml is added 
3: New pytest test_netstat.py is added

Output:

```
PLAY [Netstat module full option tests] ******************************************************************************************************************************************************************************

TASK [Run netstat with all sockets, socket options and numeric address] **********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with routing table, protocol tcp and address family inet] ******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with ras artifacts tcp, ras file and suppress nonzero] *********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with domain sockets, memory stats and pcb address] *************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with show route details, routing table and numeric address] ****************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with display interfaces, interface name ent0 and packet counts] ************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with virtual interface and cache stats] ************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with ras artifacts udp, ras file and interactive mode] *********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with display adapter statistics, numeric and pcb address] ******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with memory stats, mbuf pool stats and protocol tcp] ***********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with virtual interface, routing table and packet counts] *******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with ras artifacts tcp, ras file and protocol stats] ***********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with all sockets, pcb address and address family unix] *********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with concise protocol stats, domain sockets and pcb address] ***************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with clear interface stats, memory stats and numeric address] **************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with clear memory stats, domain sockets and address family inet] ***********************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with clear protocol stats, routing table and pcb address] ******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with display interfaces, data link stat and protocol tcp] ******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with ras artifacts udp, ras file and address family inet] ******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with protocol_stats and concise_protocol_stats] ****************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with clear stats and routing table] ****************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with clear stats and ras artifacts] ****************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with all sockets and routing table together] *******************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with clear stats and protocol stats] ***************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with clear stats and domain sockets] ***************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with clear stats and cache stats] ******************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with ras artifacts tcp, ras file, interactive and suppress nonzero] ********************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with packet counts, memory stats and pcb address] **************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with concise protocol stats, memory stats and address family inet6] ********************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

TASK [Run netstat with concise protocol stats, memory stats and address family inet4] ********************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxx]

PLAY RECAP ***********************************************************************************************************************************************************************************************************
root@xxxxxxxxxxxxxxxx        : ok=30   changed=30   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   



```