### PR TITLE
Add new iostat modules

### DIFF
--- a/playbooks/demo_iostat.yml
+++ b/playbooks/demo_iostat.yml
@@ -1,0 +1,263 @@
+- name: Run iostat command with various options on AIX
+  hosts: "{{ host_name }}"
+  gather_facts: false
+  vars:
+    host_name: usertest
+    user_name: aixguest
+    password_val: Password
+    concat_v1: 'True'
+    output_dir: "/tmp/iostatdata2"
+
+  tasks:
+    - name: Run iostat with adapter report and timestamp
+      ibm.power_aix.iostat:
+        adapter_report: true
+        extended_drive: true
+        long_list: true
+        reset_ext_stats: true
+        system_throughput: true
+        nonzero_stats: true
+        reset_io: true
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 10
+        count: 2
+    - name: Run iostat with xml_output
+      ibm.power_aix.iostat:
+        xml_output: true
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    - name: Run iostat with xml_output and output file 
+      ibm.power_aix.iostat:
+        xml_output: true
+        xml_output_path: "{{ output_dir }}/xml_iostat_output.txt"
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with xml_output and drives options 
+      ibm.power_aix.iostat:
+        xml_output: true
+        drives: 'hdisk0'
+        xml_output_path: "{{ output_dir }}/xml_iostat_output.txt"
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run iostat with block_io report
+      ibm.power_aix.iostat:
+        block_io: true
+        show_timestamp: true
+        extended_drive: true
+        nonzero_stats: true
+        reset_io: true
+        options_override: "ellipsis=on"
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 2
+        count: 1
+    - name: Run iostat with adapter report
+      ibm.power_aix.iostat:
+        adapter_report: true
+        no_tty_cpu :  true
+        extended_drive: true
+        reset_ext_stats: true
+        long_list: true
+        path_utilization: true
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        interval: 2
+        count: 1
+    - name: Run iostat with no_tty_cpu and no_disk
+      ibm.power_aix.iostat:
+        no_tty_cpu: true
+        system_throughput: true
+        no_disk: true
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with no_tty_cpu and drives
+      ibm.power_aix.iostat:
+        no_tty_cpu: true
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        
+    - name: Run iostat with extended_drive and drives, wpar
+      ibm.power_aix.iostat:
+        extended_drive: true
+        wpar_stats: 'ALL'
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+      
+    - name: Run iostat with fs_utilization and options_override 
+      ibm.power_aix.iostat:
+        fs_utilization: true
+        filesystems: "/"
+        wpar_stats: 'ALL'
+        options_override: "ellipsis=on"
+        show_timestamp: true
+        scale_power: 2
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+        
+    - name: Run iostat with fs_only and wpar_stats
+      ibm.power_aix.iostat:
+        fs_only: true
+        wpar_stats: 'ALL'
+        filesystems: "/"
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+  
+    - name: Run iostat with long_list and options_override , wpar_stats
+      ibm.power_aix.iostat:
+        long_list: true
+        wpar_stats: 'ALL'
+        options_override: "ellipsis=on"
+        scale_power: 2
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with path_utilization and reset_io, scale_power
+      ibm.power_aix.iostat:
+        path_utilization: true
+        reset_io: true
+        options_override: "ellipsis=on"
+        scale_power: 2
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    - name: Run iostat with reset_ext_stats and extended_drive, options_override
+      ibm.power_aix.iostat:
+        reset_ext_stats: true
+        options_override: "ellipsis=on"
+        extended_drive: true
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with no_disk and show_timestamp, show_timestamp 
+      ibm.power_aix.iostat:
+        no_disk: true
+        options_override: "ellipsis=on"
+        show_timestamp: true
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with system_throughput and options_override and drives
+      ibm.power_aix.iostat:
+        system_throughput: true
+        options_override: "ellipsis=on"
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with show_timestamp and wpar_stats, options_override
+      ibm.power_aix.iostat:
+        show_timestamp: true
+        wpar_stats: 'ALL'
+        options_override: "ellipsis=on"
+        scale_power: 2
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with nonzero_stats and show_timestamp, options_override
+      ibm.power_aix.iostat:
+        nonzero_stats: true
+        wpar_stats: 'ALL'
+        options_override: "ellipsis=on"
+        show_timestamp: true
+        scale_power: 2
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with reset_io and show_timestamp, options_override
+      ibm.power_aix.iostat:
+        reset_io: true
+        wpar_stats: 'ALL'
+        options_override: "ellipsis=on"
+        show_timestamp: true
+        scale_power: 2
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run iostat with scale_power and drives
+      ibm.power_aix.iostat:
+        scale_power: 2
+        options_override: "ellipsis=on"
+        show_timestamp: true
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with options_override and wpar_stats, scale_power
+      ibm.power_aix.iostat:
+        options_override: "ellipsis=on"
+        wpar_stats: 'ALL'
+        show_timestamp: true
+        scale_power: 2
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with wpar_stats, show_timestamp, scale_power, options_override
+      ibm.power_aix.iostat:
+        wpar_stats: 'ALL'
+        show_timestamp: true
+        options_override: "ellipsis=on"
+        scale_power: 2
+        drives: hdisk0
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run iostat with fs_only and wpar_stats, filesystems, options_override
+      ibm.power_aix.iostat:
+        fs_only: true
+        filesystems: "/"
+        wpar_stats: 'ALL'
+        options_override: "ellipsis=on"
+        show_timestamp: true
+        interval: 2
+        count: 1
+        recorded_output: "{{ output_dir }}/iostat_output.txt"
+        concatenated_output: "{{ concat_v1 }}"
+  
+
+
+
+

--- a/plugins/modules/iostat.py
+++ b/plugins/modules/iostat.py
@@ -14,7 +14,7 @@ author:
 short_description: Run the AIX iostat command to monitor system I/O statistics.
 description:
   - Enables Ansible to invoke AIX's iostat utility with comprehensive flag support.
-version_added: "2.1.0"
+version_added: "2.2.0"
 requirements:
   - AIX >= 7.1
 options:
@@ -155,6 +155,10 @@ options:
       - If set to false, the file will be overwritten with fresh output.
     type: bool
     required: true
+  recorded_output:
+    description:
+      - Path to file where command output should be written.
+    type: str
 
 notes:
   - You can refer to the IBM documentation for additional information on the vmstat command at

--- a/plugins/modules/iostat.py
+++ b/plugins/modules/iostat.py
@@ -128,10 +128,6 @@ options:
     description:
       - Specifies the file name for the XML output.
     type: str
-  recored_output:
-    description:
-      - folder path to command output in machine .
-    type: str
   drives:
     description:
       - List of drives to include in the report.

--- a/plugins/modules/iostat.py
+++ b/plugins/modules/iostat.py
@@ -424,7 +424,8 @@ def main():
                 try:
                     os.makedirs(output_dir, exist_ok=True)
                 except Exception as e:
-                    module.fail_json(msg=f"Failed to create directory {output_dir}: {str(e)}", **result)
+                    result['msg'] = f"Failed to create directory {output_dir}: {str(e)}"
+                    module.fail_json(**result)
             mode = 'a' if should_concat else 'w'  # 'a' = append, 'w' = overwrite
             with open(output_file, mode) as f:
                 f.write(stdout + '\n')

--- a/plugins/modules/iostat.py
+++ b/plugins/modules/iostat.py
@@ -1,0 +1,437 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020- IBM, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+DOCUMENTATION = r'''
+---
+module: iostat
+author:
+  - AIX Development Team (@vivekpandeyibm)
+short_description: Run the AIX iostat command to monitor system I/O statistics.
+description:
+  - Enables Ansible to invoke AIX's iostat utility with comprehensive flag support.
+version_added: "2.1.0"
+requirements:
+  - AIX >= 7.1
+options:
+  adapter_report:
+    description:
+      - Display the adapter throughput report (-a).
+    type: bool
+    default: false
+  block_io:
+    description:
+      - Displays the block I/O device utilization statistics. The -b flag is mutually exclusive to all flags, except the -T flag.
+    type: bool
+    default: false
+  no_tty_cpu:
+    description:
+      - Turns off the display of TTY utilization report or CPU utilization report.
+      - If you do not specify the -d or -p flag, then by default the -d flag is turned on.
+      - The -t and -d flags together turn off both disks and TTY or CPU statistics, allowed only with the -a or -s flags.
+      - The -d flag is mutually exclusive with the -t flag unless you specify the -a or -s flag, too.
+      - The -d flag is mutually exclusive with the -p flag unless you specify the -a or -s flag, too.
+    type: bool
+    default: false
+  extended_drive:
+    description:
+      - Display extended tape/drive utilization.
+    type: bool
+    default: false
+  fs_utilization:
+    description:
+      - Display file system utilization (-f).
+    type: bool
+    default: false
+  fs_only:
+    description:
+      - Displays the file system utilization report, and turns off other utilization reports..
+    type: bool
+    default: false
+  filesystems:
+    description:
+      - List of file filesystem to be used.
+    type: str
+  long_list:
+    description:
+      - Displays the output in long listing mode.
+    type: bool
+    default: false
+  path_utilization:
+    description:
+      - Displays the path utilization report.
+    type: bool
+    default: false
+  reset_ext_stats:
+    description:
+      - Specifies that the reset of min* and max* values should happen at each interval.
+      - The default is to reset the values once when iostat is started.
+      - The -R flag can be specified only with the -D flag
+    type: bool
+    default: false
+  system_throughput:
+    description:
+      - Specifies the system throughput report.
+      - You can specify the -a flag with the -A flag, but not when you have specified the -q or -Q flag.
+    type: bool
+    default: false
+  no_disk:
+    description:
+      - Turns off the display of disk utilization report.
+      - The -t and -d flags together turn off both disks and TTY or CPU statistics, allowed only with the -a or -s flags
+    type: bool
+    default: false
+  show_timestamp:
+    description:
+      - Displays the time stamp.
+    type: bool
+    default: false
+  nonzero_stats:
+    description:
+      - Display valid nonzero statistics.
+    type: bool
+    default: false
+  reset_io:
+    description:
+      - Resets the disk input/output statistics.
+      - Only root users can use this option.
+    type: bool
+    default: false
+  xml_output:
+    description:
+      - Generates the XML output.
+      - The default file name is iostat_DDMMYYHHMM.xml unless you specify a different file name by using the -o option.
+    type: bool
+    default: false
+  scale_power:
+    description:
+      - Displays the processor statistics that are multiplied by a value of 10power.
+      - The default value of the power parameter is 0
+    type: int
+  options_override:
+    description:
+       - Changes the content and presentation of the iostat report based on the values specified in option parameters.
+    type: str
+  wpar_stats:
+    description:
+      - Reports I/O activities of a workload partition.
+      - Specify -@ 'ALL' to display the activity for the global environment and all workload partitions in the system.
+      - Specify the -@ flag with a list of workload partition names to display the activity for that workload partition.
+      - Specify -@ 'Global' to display the activity for the global environment only.
+      - Specify the -@ flag inside a WPAR to display system-wide statistics along with WPAR statistics.
+    type: str
+  xml_output_path:
+    description:
+      - Specifies the file name for the XML output.
+    type: str
+  recored_output:
+    description:
+      - folder path to command output in machine .
+    type: str
+  drives:
+    description:
+      - List of drives to include in the report.
+    type: list
+    elements: str
+  interval:
+    description:
+      - Parameter specifies the amount of time in seconds between each report.
+      - If the Interval parameter is not specified, the iostat command generates a single report containing statistics for the time since system startup (boot).
+    type: int
+  count:
+    description:
+      - The Count parameter can be specified in conjunction with the Interval parameter.
+      - If the Count parameter is specified, the value of count determines the number of reports generated at Interval seconds apart.
+      - If the 'count' is not mentioned with the 'interval' option, then the default value of 5 will be considered.
+    type: int
+  concatenated_output:
+    description:
+      - Controls whether the output of the iostat command is appended to the output file or is overwrited.
+      - If set to true, output will be appended to the file.
+      - If set to false, the file will be overwritten with fresh output.
+    type: bool
+    required: true
+
+notes:
+  - You can refer to the IBM documentation for additional information on the vmstat command at
+    U(https://www.ibm.com/docs/en/aix/7.3.0?topic=i-iostat-command).
+'''
+
+EXAMPLES = r'''
+- name: Run iostat with adapter and timestamp
+  ibm.power_aix.iostat:
+    adapter_report: true
+    show_timestamp: true
+    interval: 2
+    count: 3
+
+- name: Run iostat with XML output
+  ibm.power_aix.iostat:
+    xml_output: true
+    xml_output_path: '/tmp/iostat_report.xml'
+'''
+
+RETURN = r'''
+msg:
+    description: The execution message.
+    returned: always
+    type: str
+    sample: 'iostat SUCCESSFULLY executed.'
+cmd:
+    description: The command executed.
+    returned: always
+    type: str
+rc:
+    description: The command return code.
+    returned: When the command is executed.
+    type: int
+stdout':
+    description: The standard output.
+    returned: If the command failed.
+    type: str
+stderr':
+    description: The standard error.
+    returned: If the command failed.
+    type: str
+'''
+
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import os
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+
+def build_iostat_command(module):  # A, P need "Asynchronous I/O not configured" , F have issue and -p needed " No tapes found in the system"
+
+    '''
+    Build the iostat command with specified options
+    arguments:
+        module  (dict): The Ansible module
+    Returns:
+        cmd - A successfully created iostat command
+    '''
+
+    cmd = ['iostat']
+
+    if module.params['xml_output']:
+        if any([
+            module.params['adapter_report'], module.params['no_tty_cpu'],
+            module.params['extended_drive'], module.params['fs_utilization'], module.params['fs_only'],
+            module.params['long_list'], module.params['path_utilization'],
+            module.params['reset_ext_stats'], module.params['system_throughput'], module.params['no_disk'],
+            module.params['nonzero_stats'], module.params['reset_io'], module.params['wpar_stats'],
+            module.params['block_io'], module.params['show_timestamp'], module.params['options_override'],
+            module.params['scale_power']
+        ]):
+            module.fail_json(msg="No other option except -o can be combined with -X option")
+        cmd.append('-X')
+        if module.params['xml_output_path']:
+            cmd.extend(['-o', module.params['xml_output_path']])
+    else:
+
+        if module.params['block_io']:
+            if any([
+                module.params['adapter_report'], module.params['no_tty_cpu'],
+                module.params['fs_utilization'], module.params['fs_only'],
+                module.params['long_list'], module.params['path_utilization'],
+                module.params['reset_ext_stats'], module.params['system_throughput'], module.params['no_disk'],
+                module.params['wpar_stats'], module.params['scale_power']
+            ]):
+                module.fail_json(msg="-b is mutually exclusive with all flags except -T, -D, -O, -V , -z.")
+            elif not (module.params['interval']):
+                module.fail_json(msg="interval is missing with -b option.")
+            cmd.append('-b')
+        if module.params['adapter_report']:
+            if any([module.params['fs_utilization'], module.params['fs_only'], module.params['wpar_stats']]):
+                module.fail_json(msg="-a is mutually exclusive with:  -f, -F, -@, -X, -b")
+            cmd.append('-a')
+        if module.params['no_tty_cpu']:
+            if module.params['no_disk'] and not (module.params['adapter_report'] or module.params['system_throughput']):
+                module.fail_json(msg="-d and -t cannot be used together unless -a or -s is specified")
+            elif any([
+                module.params['fs_only'], module.params['xml_output'], module.params['scale_power']
+            ]):
+                module.fail_json(msg="-d is mutually exclusive with: -F, -X, -S,")
+
+            cmd.append('-d')
+
+        if module.params['extended_drive']:
+            if module.params['no_disk'] and not (module.params['adapter_report'] or module.params['system_throughput']):
+                module.fail_json(msg="-D and -t together only allowed with -a or -s.")
+            elif any([
+                module.params['fs_utilization'], module.params['fs_only'], module.params['scale_power']
+            ]):
+                module.fail_json(msg="-D is mutually exclusive with: -f, -F, -P, -q, -Q, -S,")
+            cmd.append('-D')
+        if module.params['fs_utilization']:
+            if any([
+                module.params['adapter_report'], module.params['extended_drive'], module.params['fs_only'],
+            ]):
+                module.fail_json(msg="-f is mutually exclusive with -a, -D, -F, ")
+            cmd.append('-f')
+            if module.params['filesystems']:
+                cmd.append(str(module.params['filesystems']))
+
+        if module.params['long_list']:
+            cmd.append('-l')
+
+        if module.params['path_utilization']:
+            if any([
+                module.params['fs_only'], module.params['wpar_stats'],
+                module.params['no_disk'], module.params['wpar_stats']
+            ]):
+                module.fail_json(msg="-m is mutually exclusive with  -F,  -t, -@")
+            cmd.append('-m')
+
+        if module.params['reset_ext_stats']:
+            if not module.params['extended_drive']:
+                module.fail_json(msg="The -R option can only be used together with -D.")
+            cmd.append('-R')
+
+        if module.params['system_throughput']:
+            if any([
+                module.params['wpar_stats']
+            ]):
+                module.fail_json(msg="-s is mutually exclusive with  -@")
+            cmd.append('-s')
+
+        if module.params['no_disk']:
+            if any([
+                module.params['reset_io'], module.params['wpar_stats']
+            ]):
+                module.fail_json(msg="-t is mutually exclusive with -z, -@")
+            cmd.append('-t')
+
+        if module.params['show_timestamp']:
+            cmd.append('-T')
+
+        if module.params['nonzero_stats']:
+            cmd.append('-V')
+
+        if module.params['reset_io']:
+            cmd.append('-z')
+
+        if module.params['scale_power'] is not None:
+            cmd.extend(['-S', str(module.params['scale_power'])])
+
+        if module.params['options_override']:
+            cmd.extend(['-O', module.params['options_override']])
+
+        if module.params['wpar_stats']:
+            if any([
+                module.params['adapter_report'], module.params['no_disk'], module.params['reset_ext_stats'],
+                module.params['path_utilization'], module.params['system_throughput']
+            ]):
+                module.fail_json(msg="-@ cannot be used with -a, -t, -R, -s, or -m.")
+            cmd.extend(['-@', module.params['wpar_stats']])
+
+        if module.params['fs_only']:
+            if any([
+                module.params['adapter_report'], module.params['no_tty_cpu'], module.params['extended_drive'],
+                module.params['fs_utilization'], module.params['path_utilization'],
+                module.params['reset_ext_stats'], module.params['no_disk'],
+                module.params['reset_io'], module.params['scale_power'], module.params['reset_ext_stats']
+            ]):
+                module.fail_json(msg="-F is mutually exclusive with -a, -d, -D, -f, -m, -R, -t -z , -S")
+            cmd.append('-F')
+            if module.params['filesystems']:
+                cmd.append(str(module.params['filesystems']))
+
+    if module.params['drives']:
+        if any([
+            module.params['fs_only']
+        ]):
+            module.fail_json(msg=" 'drives' cannot be used with -F  Option.")
+        cmd.extend(module.params['drives'])
+
+    if module.params['interval'] is not None:
+        cmd.append(str(module.params['interval']))
+        if module.params['count'] is not None:
+            cmd.append(str(module.params['count']))
+        else:
+            module.params['count'] = 5
+            cmd.append(str(module.params['count']))
+    return cmd
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            adapter_report=dict(type='bool', default=False),
+            block_io=dict(type='bool', default=False),
+            no_tty_cpu=dict(type='bool', default=False),
+            extended_drive=dict(type='bool', default=False),
+            fs_utilization=dict(type='bool', default=False),
+            fs_only=dict(type='bool', default=False),
+            long_list=dict(type='bool', default=False),
+            path_utilization=dict(type='bool', default=False),
+            reset_ext_stats=dict(type='bool', default=False),
+            system_throughput=dict(type='bool', default=False),
+            no_disk=dict(type='bool', default=False),
+            show_timestamp=dict(type='bool', default=False),
+            nonzero_stats=dict(type='bool', default=False),
+            reset_io=dict(type='bool', default=False),
+            xml_output=dict(type='bool', default=False),
+            scale_power=dict(type='int'),
+            options_override=dict(type='str'),
+            filesystems=dict(type='str'),
+            wpar_stats=dict(type='str'),
+            xml_output_path=dict(type='str'),
+            drives=dict(type='list', elements='str'),
+            recorded_output=dict(type='str'),
+            concatenated_output=dict(type='bool', required=True),
+            interval=dict(type='int'),
+            count=dict(type='int')
+        ),
+        supports_check_mode=False
+    )
+
+    cmd = build_iostat_command(module)
+    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=False)
+
+    result = {
+        'changed': True,
+        'cmd': ' '.join(cmd),
+        'rc': rc,
+        'stdout': stdout,
+        'stderr': stderr
+    }
+
+    if rc != 0:
+        result['msg'] = f"iostat command failed with command  {cmd}"
+        module.fail_json(**result)
+    else:
+
+        if module.params['recorded_output']:
+            output_file = module.params['recorded_output']
+            should_concat = module.params['concatenated_output']
+            output_dir = os.path.dirname(output_file)
+            if output_dir and not os.path.exists(output_dir):
+                try:
+                    os.makedirs(output_dir, exist_ok=True)
+                except Exception as e:
+                    module.fail_json(msg=f"Failed to create directory {output_dir}: {str(e)}", **result)
+            mode = 'a' if should_concat else 'w'  # 'a' = append, 'w' = overwrite
+            with open(output_file, mode) as f:
+                f.write(stdout + '\n')
+            result['changed'] = True
+            result['msg'] = f"iostat executed successfully with command '{cmd}' and Output written to {output_file}"
+        else:
+            result['changed'] = False
+            result['msg'] = f"iostat executed successfully with command '{cmd}'"
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/plugins/modules/test_iostat.py
+++ b/tests/unit/plugins/modules/test_iostat.py
@@ -1,0 +1,334 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest import mock
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.power_aix.plugins.modules import iostat
+from .common.utils import fail_json, AnsibleFailJson
+
+
+class TestIostatModule(unittest.TestCase):
+    def setUp(self):
+        self.module = mock.Mock(spec=AnsibleModule)
+        self.module.fail_json = fail_json
+        self.module.fail_json.side_effect = AnsibleFailJson
+
+        self.params = {
+            'adapter_report': False,
+            'block_io': False,
+            'no_tty_cpu': False,
+            'extended_drive': False,
+            'fs_utilization': False,
+            'fs_only': False,
+            'long_list': False,
+            'path_utilization': False,
+            'reset_ext_stats': False,
+            'system_throughput': False,
+            'no_disk': False,
+            'show_timestamp': False,
+            'nonzero_stats': False,
+            'reset_io': False,
+            'xml_output': False,
+            'scale_power': None,
+            'options_override': None,
+            'filesystems': None,
+            'wpar_stats': None,
+            'xml_output_path': None,
+            'drives': None,
+            'recorded_output': "/tmp/iostatdata/iostat_output.txt",
+            'concatenated_output': True,
+            'interval': None,
+            'count': None
+        }
+        self.module.params = self.params
+
+    def test_xml_output_conflict(self):
+        self.module.params.update({'xml_output': True, 'adapter_report': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("No other option except -o can be combined with -X option", str(err.exception))
+
+    def test_block_io_missing_interval(self):
+        self.module.params['block_io'] = True
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("interval is missing with -b option.", str(err.exception))
+
+    def test_block_io_mutual_exclusion(self):
+        self.module.params.update({'block_io': True, 'adapter_report': True, 'interval': 1})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-b is mutually exclusive with all flags except -T, -D, -O, -V , -z.", str(err.exception))
+
+    def test_adapter_report_conflict_fs_utilization(self):
+        self.module.params.update({'adapter_report': True, 'fs_utilization': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-a is mutually exclusive with:  -f, -F, -@, -X, -b", str(err.exception))
+
+    def test_no_tty_cpu_conflict_fs_only(self):
+        self.module.params.update({'no_tty_cpu': True, 'fs_only': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-d is mutually exclusive with: -F, -X, -S,", str(err.exception))
+
+    def test_no_tty_cpu_and_no_disk_invalid(self):
+        self.module.params.update({'no_tty_cpu': True, 'no_disk': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-d and -t cannot be used together unless -a or -s is specified", str(err.exception))
+
+    def test_extended_drive_conflict_fs_utilization(self):
+        self.module.params.update({'extended_drive': True, 'fs_utilization': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-D is mutually exclusive with: -f, -F, -P, -q, -Q, -S,", str(err.exception))
+
+    def test_extended_drive_and_no_disk_invalid(self):
+        self.module.params.update({'extended_drive': True, 'no_disk': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-D and -t together only allowed with -a or -s.", str(err.exception))
+
+    def test_reset_ext_stats_requires_extended_drive(self):
+        self.module.params['reset_ext_stats'] = True
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("The -R option can only be used together with -D.", str(err.exception))
+
+    def test_fs_utilization_conflict_adapter_report(self):
+        self.module.params.update({'fs_utilization': True, 'adapter_report': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-a is mutually exclusive with:  -f, -F, -@, -X, -b", str(err.exception))
+
+    def test_path_utilization_conflict_fs_only(self):
+        self.module.params.update({'path_utilization': True, 'fs_only': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-m is mutually exclusive with  -F,  -t, -@", str(err.exception))
+
+    def test_system_throughput_conflict_wpar(self):
+        self.module.params.update({'system_throughput': True, 'wpar_stats': 'ALL'})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-s is mutually exclusive with  -@", str(err.exception))
+
+    def test_no_disk_reset_io_conflict(self):
+        self.module.params.update({'no_disk': True, 'reset_io': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-t is mutually exclusive with -z, -@", str(err.exception))
+
+    def test_wpar_stats_with_adapter_report(self):
+        self.module.params.update({'wpar_stats': 'ALL', 'adapter_report': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-a is mutually exclusive with:  -f, -F, -@, -X, -b", str(err.exception))
+
+    def test_drives_and_fs_only_conflict(self):
+        self.module.params.update({'fs_only': True, 'drives': ['hdisk0']})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn(" 'drives' cannot be used with -F  Option.", str(err.exception))
+
+    def test_fs_only_mutuals(self):
+        self.module.params.update({'fs_only': True, 'adapter_report': True})
+        with self.assertRaises(AnsibleFailJson) as err:
+            iostat.build_iostat_command(self.module)
+        self.assertIn("-a is mutually exclusive with:  -f, -F, -@, -X, -b", str(err.exception))
+
+    def test_valid_basic_xml(self):
+        self.module.params.update({'xml_output': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-X'])
+
+    def test_valid_extended_drive_and_reset_ext_stats(self):
+        self.module.params.update({'extended_drive': True, 'reset_ext_stats': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-D', '-R'])
+
+    def test_valid_block_io(self):
+        self.module.params.update({'block_io': True, 'interval': 2})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-b', '2'])
+
+    def test_valid_adapter_report(self):
+        self.module.params.update({'adapter_report': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-a'])
+
+    def test_valid_path_utilization(self):
+        self.module.params.update({'path_utilization': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-m'])
+
+    def test_valid_filesystems_fs_utilization(self):
+        self.module.params.update({'fs_utilization': True, 'filesystems': '/'})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-f', '/'])
+
+    def test_valid_drives(self):
+        self.module.params.update({'drives': ['hdisk0']})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', 'hdisk0'])
+
+    def test_valid_scale_power(self):
+        self.module.params.update({'scale_power': 2})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-S', '2'])
+
+    def test_valid_options_override(self):
+        self.module.params.update({'options_override': 'ellipsis=on'})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-O', 'ellipsis=on'])
+
+    def test_valid_wpar_stats(self):
+        self.module.params.update({'wpar_stats': 'ALL'})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-@', 'ALL'])
+
+    def test_valid_show_timestamp(self):
+        self.module.params.update({'show_timestamp': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-T'])
+
+    def test_valid_nonzero_stats(self):
+        self.module.params.update({'nonzero_stats': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-V'])
+
+    def test_valid_reset_io(self):
+        self.module.params.update({'reset_io': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-z'])
+
+    def test_valid_interval_count(self):
+        self.module.params.update({'interval': 2, 'count': 5})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '2', '5'])
+
+    def test_all_defaults(self):
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat'])
+
+    # The extra 15 realistic valid combos:
+    def test_adapter_report_with_timestamp(self):
+        self.module.params.update({'adapter_report': True, 'show_timestamp': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-a', '-T'])
+
+    def test_adapter_report_with_drives_and_interval(self):
+        self.module.params.update({
+            'adapter_report': True,
+            'drives': ['hdisk0'],
+            'interval': 5
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-a', 'hdisk0', '5'])
+
+    def test_extended_drive_with_scale_and_override(self):
+        self.module.params.update({
+            'extended_drive': True,
+            'reset_ext_stats': True,
+            'options_override': 'detail=on'
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-D', '-R', '-O', 'detail=on'])
+
+    def test_block_io_with_reset_io_and_override(self):
+        self.module.params.update({
+            'block_io': True,
+            'interval': 2,
+            'reset_io': True,
+            'options_override': 'ell=on'
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-b', '-z', '-O', 'ell=on', '2'])
+
+    def test_block_io_with_nonzero_stats(self):
+        self.module.params.update({
+            'block_io': True,
+            'interval': 1,
+            'nonzero_stats': True
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-b', '-V', '1'])
+
+    def test_reset_io_and_nonzero_stats(self):
+        self.module.params.update({'reset_io': True, 'nonzero_stats': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-V', '-z'])
+
+    def test_system_throughput_and_show_timestamp(self):
+        self.module.params.update({'system_throughput': True, 'show_timestamp': True})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-s', '-T'])
+
+    def test_long_list_with_drives(self):
+        self.module.params.update({'long_list': True, 'drives': ['hdisk0']})
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-l', 'hdisk0'])
+
+    def test_fs_utilization_with_override_and_scale(self):
+        self.module.params.update({
+            'fs_utilization': True,
+            'filesystems': '/',
+            'options_override': 'detail=on',
+            'scale_power': 1
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-f', '/', '-S', '1', '-O', 'detail=on'])
+
+    def test_valid_wpar_stats_with_drives(self):
+        self.module.params.update({
+            'wpar_stats': 'ALL',
+            'drives': ['hdisk0']
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-@', 'ALL', 'hdisk0'])
+
+    def test_valid_reset_io_with_drives_and_interval(self):
+        self.module.params.update({
+            'reset_io': True,
+            'drives': ['hdisk0'],
+            'interval': 2
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-z', 'hdisk0', '2'])
+
+    def test_valid_show_timestamp_with_drives_and_count(self):
+        self.module.params.update({
+            'show_timestamp': True,
+            'drives': ['hdisk0'],
+            'interval': 2,
+            'count': 2
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-T', 'hdisk0', '2', '2'])
+
+    def test_valid_nonzero_stats_with_drives(self):
+        self.module.params.update({
+            'nonzero_stats': True,
+            'drives': ['hdisk0']
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-V', 'hdisk0'])
+
+    def test_valid_scale_power_with_drives_and_override(self):
+        self.module.params.update({
+            'scale_power': 2,
+            'options_override': 'perf=on',
+            'drives': ['hdisk0']
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-S', '2', '-O', 'perf=on', 'hdisk0'])
+
+    def test_valid_interval_count_drives_show_timestamp(self):
+        self.module.params.update({
+            'interval': 2,
+            'count': 2,
+            'drives': ['hdisk0'],
+            'show_timestamp': True
+        })
+        cmd = iostat.build_iostat_command(self.module)
+        self.assertEqual(cmd, ['iostat', '-T', 'hdisk0', '2', '2'])

--- a/tests/unit/plugins/modules/test_iostat.py
+++ b/tests/unit/plugins/modules/test_iostat.py
@@ -150,7 +150,7 @@ class TestIostatModule(unittest.TestCase):
     def test_valid_block_io(self):
         self.module.params.update({'block_io': True, 'interval': 2})
         cmd = iostat.build_iostat_command(self.module)
-        self.assertEqual(cmd, ['iostat', '-b', '2'])
+        self.assertEqual(cmd, ['iostat', '-b', '2', '5'])
 
     def test_valid_adapter_report(self):
         self.module.params.update({'adapter_report': True})
@@ -224,7 +224,7 @@ class TestIostatModule(unittest.TestCase):
             'interval': 5
         })
         cmd = iostat.build_iostat_command(self.module)
-        self.assertEqual(cmd, ['iostat', '-a', 'hdisk0', '5'])
+        self.assertEqual(cmd, ['iostat', '-a', 'hdisk0', '5', '5'])
 
     def test_extended_drive_with_scale_and_override(self):
         self.module.params.update({
@@ -243,7 +243,7 @@ class TestIostatModule(unittest.TestCase):
             'options_override': 'ell=on'
         })
         cmd = iostat.build_iostat_command(self.module)
-        self.assertEqual(cmd, ['iostat', '-b', '-z', '-O', 'ell=on', '2'])
+        self.assertEqual(cmd, ['iostat', '-b', '-z', '-O', 'ell=on', '2', '5'])
 
     def test_block_io_with_nonzero_stats(self):
         self.module.params.update({
@@ -252,7 +252,7 @@ class TestIostatModule(unittest.TestCase):
             'nonzero_stats': True
         })
         cmd = iostat.build_iostat_command(self.module)
-        self.assertEqual(cmd, ['iostat', '-b', '-V', '1'])
+        self.assertEqual(cmd, ['iostat', '-b', '-V', '1', '5'])
 
     def test_reset_io_and_nonzero_stats(self):
         self.module.params.update({'reset_io': True, 'nonzero_stats': True})
@@ -294,7 +294,7 @@ class TestIostatModule(unittest.TestCase):
             'interval': 2
         })
         cmd = iostat.build_iostat_command(self.module)
-        self.assertEqual(cmd, ['iostat', '-z', 'hdisk0', '2'])
+        self.assertEqual(cmd, ['iostat', '-z', 'hdisk0', '2', '5'])
 
     def test_valid_show_timestamp_with_drives_and_count(self):
         self.module.params.update({


### PR DESCRIPTION
1: New module iostat .py is added. The iostat command is the fastest way to get a first impression, whether or not the system has a disk I/O-bound performance problem
2: New Playbook demo_iostat .yml is added 
3: New pytest test_iostat .py is added

```
PLAY [Run iostat command with various options on AIX] ****************************************************************************************************************************************************************

TASK [Run iostat with adapter report and timestamp] ******************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with xml_output] ************************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with xml_output and output file] ********************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with xml_output and drives options] *****************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with block_io report] *******************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with adapter report] ********************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with no_tty_cpu and no_disk] ************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with no_tty_cpu and drives] *************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with extended_drive and drives, wpar] ***************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with fs_utilization and options_override] ***********************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with fs_only and wpar_stats] ************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with long_list and options_override , wpar_stats] ***************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with path_utilization and reset_io, scale_power] ****************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with reset_ext_stats and extended_drive, options_override] ******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with no_disk and show_timestamp, show_timestamp] ****************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with system_throughput and options_override and drives] *********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with show_timestamp and wpar_stats, options_override] ***********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with nonzero_stats and show_timestamp, options_override] ********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with reset_io and show_timestamp, options_override] *************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with scale_power and drives] ************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with options_override and wpar_stats, scale_power] **************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with wpar_stats, show_timestamp, scale_power, options_override] *************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

TASK [Run iostat with fs_only and wpar_stats, filesystems, options_override] *****************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxx]

PLAY RECAP ***********************************************************************************************************************************************************************************************************
root@xxxxxxxxxxxxxxxxx : ok=23   changed=23   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   




```