### PR TITLE
Add new fcstat modules

### DIFF
--- a/playbooks/demo_fcstat.yml
+++ b/playbooks/demo_fcstat.yml
@@ -1,0 +1,71 @@
+---
+- name: Run fcstat command with various options on AIX
+  hosts: "{{ host_name }}"
+  gather_facts: false
+  vars:
+    host_name: fcstat
+    user_name: aixguest
+    password_val: Password
+    concat_v1: 'True'
+    output_dir: "/tmp/fcstatdata"
+
+  tasks:
+
+    - name: Run fcstat with default stats on fcs0
+      ibm.power_aix.fcstat:
+        device_name: fcs0
+        recorded_output: "{{ output_dir }}/fcstat_output1.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run fcstat with reset stats
+      ibm.power_aix.fcstat:
+        device_name: fcs0
+        reset_stats: true
+        recorded_output: "{{ output_dir }}/fcstat_output2.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    
+    - name: Run fcstat in remove delay
+      ibm.power_aix.fcstat:
+        device_name: fcs0
+        remove_delay: true
+        recorded_output: "{{ output_dir }}/fcstat_output3.txt"
+        concatenated_output: "{{ concat_v1 }}"     
+
+    - name: Run fcstat with all_statistics option
+      ibm.power_aix.fcstat:
+        device_name: fcs0
+        all_statistics: true
+        recorded_output: "{{ output_dir }}/fcstat_output5.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run fcstat with all_statistics and remove_delay
+      ibm.power_aix.fcstat:
+        device_name: fcs0
+        all_statistics: true
+        remove_delay: true
+        recorded_output: "{{ output_dir }}/fcstat_output6.txt"
+        concatenated_output: "{{ concat_v1 }}"
+    - name: Run fcstat time-series with 5 second interval
+      ibm.power_aix.fcstat:
+        device_name: fcs0
+        interval: 2
+        count: 15
+        recorded_output: "{{ output_dir }}/fcstat_timeseries.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run fcstat time-series for SCSI protocol
+      ibm.power_aix.fcstat:
+        device_name: fcs0
+        interval: 2
+        count: 15
+        protocol: scsi
+        recorded_output: "{{ output_dir }}/fcstat_scsi_timeseries1.txt"
+        concatenated_output: "{{ concat_v1 }}"
+
+    - name: Run fcstat time-series with interval 1 (single report)
+      ibm.power_aix.fcstat:
+        device_name: fcs0
+        interval: 1
+        count: 5
+        recorded_output: "{{ output_dir }}/fcstat_single.txt"
+        concatenated_output: "{{ concat_v1 }}"

--- a/plugins/modules/fcstat.py
+++ b/plugins/modules/fcstat.py
@@ -12,7 +12,7 @@ module: fcstat
 author:
   - AIX Development Team (@vivekpandeyibm)
 short_description: Collects Fibre Channel adapter statistics using the fcstat command on AIX
-version_added: "2.1.0"
+version_added: "2.2.0"
 description:
   - This module allows you to gather statistics from Fibre Channel (FC) adapters using the AIX fcstat command.
   - Supports device-generic and device-specific reporting, diagnostic mode, reset, and time-series reporting.

--- a/plugins/modules/fcstat.py
+++ b/plugins/modules/fcstat.py
@@ -1,0 +1,259 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025- IBM, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+DOCUMENTATION = r'''
+---
+module: fcstat
+author:
+  - AIX Development Team (@vivekpandeyibm)
+short_description: Collects Fibre Channel adapter statistics using the fcstat command on AIX
+version_added: "2.1.0"
+description:
+  - This module allows you to gather statistics from Fibre Channel (FC) adapters using the AIX fcstat command.
+  - Supports device-generic and device-specific reporting, diagnostic mode, reset, and time-series reporting.
+options:
+  device_name:
+    description:
+      - Name of the Fibre Channel device (for example, fcs0).
+    type: str
+    required: true
+  remove_delay:
+    description:
+      - Removes delay in generating output when the device is opened in nondiagnostic mode and the link is down.
+    type: bool
+    default: false
+  all_statistics:
+    description:
+      - Displays all statistics, including device-specific statistics (-e).
+    type: bool
+    default: false
+  reset_stats:
+    description:
+      - Resets some statistics back to initial values (-z).
+      - Only privileged users can issue this flag.
+    type: bool
+    default: false
+  interval:
+    description:
+      - Displays a time-series report of the traffic statistics continuously with a time interval between two consecutive reports,.
+      - If set to 0, only a single report is generated.
+    type: int
+  count:
+    description:
+      - Number of reports to generate at the specified interval.
+      - Must be used together with the interval option.
+    type: int
+  protocol:
+    description:
+      - Displays a time-series report of traffic statistics for a specific transport protocol (TP) that is specified with the Protocol parameter.
+    type: str
+  recorded_output:
+    description:
+      - Path to file where command output should be written.
+    type: str
+  concatenated_output:
+    description:
+      - Controls whether the output is appended to the file or overwrites it.
+    type: bool
+    required: true
+notes:
+  - You can refer to the IBM documentation for additional information on the fcstat command at
+    U(https://www.ibm.com/docs/en/aix/7.3.0?topic=f-fcstat-command).
+'''
+
+EXAMPLES = r'''
+- name: Run fcstat on fcs0 with generic stats
+  ibm.power_aix.fcstat:
+    device_name: fcs0
+
+- name: Run fcstat with extended stats on fcs1
+  ibm.power_aix.fcstat:
+    device_name: fcs1
+    extended_stats: true
+
+- name: Run fcstat in diagnostic mode and reset stats
+  ibm.power_aix.fcstat:
+    device_name: fcs0
+    diagnostic_mode: true
+    reset_stats: true
+
+- name: Run fcstat time-series with 5 second interval, 3 reports
+  ibm.power_aix.fcstat:
+    device_name: fcs0
+    interval: 5
+    protocol: scsi
+'''
+
+RETURN = r'''
+msg:
+    description: Execution message indicating success or failure.
+    returned: always
+    type: str
+    sample: 'fcstat executed successfully with given options.'
+cmd:
+    description: Full fcstat command executed.
+    returned: always
+    type: str
+    sample: 'fcstat -e fcs0'
+rc:
+    description: Return code from fcstat command.
+    returned: always
+    type: int
+stdout:
+    description: Standard output from fcstat command.
+    returned: always
+    type: str
+stderr:
+    description: Error output from fcstat command (if any).
+    returned: on failure
+    type: str
+'''
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import os
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+
+def is_valid_device(module, device_name):
+    """
+    Check if the given device exists in ODM.
+    Returns True if valid, False otherwise.
+    """
+    cmd = ["lsdev", "-C", "-l", device_name, "-F", "name"]
+    rc, stdout, stderr = module.run_command(cmd)
+
+    if rc != 0 or not stdout.strip():
+        module.fail_json(msg=f"Invalid device: {device_name}. Please specify a valid AIX FC adapter (e.g., fcs0).")
+    return True
+
+
+def validate_mutual_exclusiveness(module):
+    '''
+    Validate flag combinations for fcstat
+    '''
+    if module.params['device_name']:
+        device_name = module.params['device_name']
+        is_valid_device(module, device_name)
+    if module.params['protocol'] and not module.params['interval']:
+        module.fail_json(msg="'protocol' (-p) requires 'interval' (-t).")
+
+    if module.params['reset_stats'] and module.params['all_statistics']:
+        module.fail_json(msg="'reset_stats' and 'all_statistics' can not use togather.")
+    if module.params['reset_stats'] and module.params['remove_delay']:
+        module.fail_json(msg="'reset_stats' (-z) can not be use with option 'remove_delay' (-c).")
+    # 'interval' and 'count' must always be used together
+    if bool(module.params.get('interval')) != bool(module.params.get('count')):
+        module.fail_json(msg="Options 'interval' and 'count' must be used together.")
+
+    if (module.params.get('interval') or module.params.get('protocol')):
+        if (module.params.get('reset_stats') or module.params.get('all_statistics') or module.params.get('remove_delay')):
+            module.fail_json(msg=(
+                "Options '-z', '-e', or '-c' cannot be used together with "
+                "'-t Interval' or '-p Protocol'."
+            ))
+
+
+def build_fcstat_command(module):
+    '''
+    Build fcstat command from module parameters
+    '''
+    cmd = ['fcstat']
+
+    if module.params['reset_stats']:
+        cmd.append('-z')
+        if module.params['remove_delay']:
+            cmd.append('-c')
+
+    elif module.params['all_statistics']:
+        cmd.append('-e')
+        if module.params['remove_delay']:
+            cmd.append('-c')
+    elif module.params['remove_delay']:
+        cmd.append('-c')
+
+    if module.params['interval'] is not None:
+        cmd.extend(['-t', str(module.params['interval'])])
+        if module.params['protocol']:
+            cmd.extend(['-p', module.params['protocol']])
+
+    if module.params['device_name'] is not None:
+        cmd.append(module.params['device_name'])
+
+    if module.params['interval'] is not None:
+        if module.params['count'] is not None:
+            count_value = int(module.params['count'])
+            count_value = count_value + 5
+            awk_filter = (f"awk 'NR > {count_value} {{exit}} {{print}}'")
+            cmd = " ".join(cmd)
+            cmd = f"unbuffer sh -c '{cmd}' | {awk_filter}"
+            return cmd
+    return cmd
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            device_name=dict(type='str', required=True),
+            remove_delay=dict(type='bool', default=False),
+            all_statistics=dict(type='bool', default=False),
+            reset_stats=dict(type='bool', default=False),
+            interval=dict(type='int'),
+            count=dict(type='int'),
+            protocol=dict(type='str'),
+            recorded_output=dict(type='str'),
+            concatenated_output=dict(type='bool', required=True),
+        ),
+        supports_check_mode=False
+    )
+
+    result = dict(changed=False, msg='', cmd='', rc=0, stdout='', stderr='')
+
+    validate_mutual_exclusiveness(module)
+    cmd = build_fcstat_command(module)
+    result['cmd'] = " ".join(cmd)
+    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
+
+    result = {
+        'changed': False,
+        'cmd': cmd,
+        'rc': rc,
+        'stdout': stdout,
+        'stderr': stderr
+    }
+
+    if rc != 0:
+        result['msg'] = f"fcstat command failed with command  {cmd}"
+        module.fail_json(**result)
+    else:
+        if module.params['recorded_output']:
+            output_file = module.params['recorded_output']
+            mode = 'a' if module.params['concatenated_output'] else 'w'
+            output_dir = os.path.dirname(output_file)
+            if output_dir and not os.path.exists(output_dir):
+                try:
+                    os.makedirs(output_dir, exist_ok=True)
+                except Exception as e:
+                    module.fail_json(msg=f"Failed to create directory {output_dir}: {str(e)}", **result)
+            with open(output_file, mode) as f:
+                f.write(stdout + '\n')
+            result['changed'] = True
+            result['msg'] = f"fcstat executed successfully with command '{cmd}' and output written to {output_file}"
+        else:
+            result['msg'] = f"fcstat executed successfully with command '{cmd}'"
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/plugins/modules/test_fcstat.py
+++ b/tests/unit/plugins/modules/test_fcstat.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest import mock
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.power_aix.plugins.modules import fcstat
+from .common.utils import fail_json, AnsibleFailJson
+
+
+class TestFcstatModule(unittest.TestCase):
+
+    def setUp(self):
+        self.module = mock.Mock(spec=AnsibleModule)
+        self.module.fail_json = fail_json
+        self.module.fail_json.side_effect = AnsibleFailJson
+        self.module.run_command = mock.Mock(return_value=(0, "ok", ""))
+
+        self.params = {
+            'device_name': 'fcs0',
+            'remove_delay': False,
+            'all_statistics': False,
+            'reset_stats': False,
+            'interval': None,
+            'count': None,
+            'protocol': None,
+            'recorded_output': None,
+            'concatenated_output': True
+        }
+        self.module.params = self.params
+
+    # 1. Default command
+    def test_default_command(self):
+        cmd = fcstat.build_fcstat_command(self.module)
+        self.assertEqual(cmd, ['fcstat', 'fcs0'])
+
+    # 2. With -z reset_stats
+    def test_reset_stats_command(self):
+        self.module.params.update({'reset_stats': True})
+        cmd = fcstat.build_fcstat_command(self.module)
+        self.assertEqual(cmd, ['fcstat', '-z', 'fcs0'])
+
+    # 3. With -e all_statistics
+    def test_all_statistics_command(self):
+        self.module.params.update({'all_statistics': True})
+        cmd = fcstat.build_fcstat_command(self.module)
+        self.assertEqual(cmd, ['fcstat', '-e', 'fcs0'])
+
+    # 4. With -c remove_delay
+    def test_remove_delay_command(self):
+        self.module.params.update({'remove_delay': True})
+        cmd = fcstat.build_fcstat_command(self.module)
+        self.assertEqual(cmd, ['fcstat', '-c', 'fcs0'])
+
+    # 5. With reset_stats and remove_delay (-z -c)
+    def test_reset_with_remove_delay(self):
+        self.module.params.update({'reset_stats': True, 'remove_delay': True})
+        cmd = fcstat.build_fcstat_command(self.module)
+        self.assertEqual(cmd, ['fcstat', '-z', '-c', 'fcs0'])
+
+    # 6. With all_statistics and remove_delay (-e -c)
+    def test_all_statistics_with_remove_delay(self):
+        self.module.params.update({'all_statistics': True, 'remove_delay': True})
+        cmd = fcstat.build_fcstat_command(self.module)
+        self.assertEqual(cmd, ['fcstat', '-e', '-c', 'fcs0'])
+
+    # 7. With interval and protocol (-t -p)
+    def test_interval_and_protocol_command(self):
+        self.module.params.update({'interval': 5, 'count': 2, 'protocol': 'scsi'})
+        cmd = fcstat.build_fcstat_command(self.module)
+        self.assertIn('-t 5', cmd)
+        self.assertIn('-p scsi', cmd)
+
+    # 8. interval without count (should fail)
+    def test_interval_without_count_fails(self):
+        self.module.params.update({'interval': 5})
+        with self.assertRaises(AnsibleFailJson):
+            fcstat.validate_mutual_exclusiveness(self.module)
+
+    # 9. count without interval (should fail)
+    def test_count_without_interval_fails(self):
+        self.module.params.update({'count': 3})
+        with self.assertRaises(AnsibleFailJson):
+            fcstat.validate_mutual_exclusiveness(self.module)
+
+    # 10. protocol without interval (should fail)
+    def test_protocol_without_interval_fails(self):
+        self.module.params.update({'protocol': 'scsi'})
+        with self.assertRaises(AnsibleFailJson):
+            fcstat.validate_mutual_exclusiveness(self.module)
+
+    # 11. reset_stats and all_statistics together (should fail)
+    def test_reset_and_all_statistics_mutual_exclusive(self):
+        self.module.params.update({'reset_stats': True, 'all_statistics': True})
+        with self.assertRaises(AnsibleFailJson):
+            fcstat.validate_mutual_exclusiveness(self.module)
+
+    # 12. interval + reset_stats conflict (should fail)
+    def test_interval_and_reset_stats_conflict(self):
+        self.module.params.update({'interval': 5, 'count': 3, 'reset_stats': True})
+        with self.assertRaises(AnsibleFailJson):
+            fcstat.validate_mutual_exclusiveness(self.module)
+
+    # 13. interval + remove_delay conflict (should fail)
+    def test_interval_and_remove_delay_conflict(self):
+        self.module.params.update({'interval': 5, 'count': 2, 'remove_delay': True})
+        with self.assertRaises(AnsibleFailJson):
+            fcstat.validate_mutual_exclusiveness(self.module)
+    # 14. Validate valid device check
+    def test_is_valid_device_success(self):
+        self.module.run_command.return_value = (0, "fcs0", "")
+        valid = fcstat.is_valid_device(self.module, "fcs0")
+        self.assertTrue(valid)
+
+    # 15. Invalid device should raise fail_json
+    def test_is_valid_device_fail(self):
+        self.module.run_command.return_value = (1, "", "error")
+        with self.assertRaises(AnsibleFailJson):
+            fcstat.is_valid_device(self.module, "invalid_fcs")
+
+    # 16. interval + count => awk generation check
+    def test_command_with_interval_count_generates_awk(self):
+        self.module.params.update({'interval': 5, 'count': 2})
+        cmd = fcstat.build_fcstat_command(self.module)
+        self.assertIn("awk", cmd)
+        self.assertIn("unbuffer", cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1: New module fcstat.py is added. The entstat command Displays the statistics that are gathered by the specified physical or virtual Fibre Channel (FC) device driver
2: New Playbook demo_fcstat.yml is added 
3: New pytest test_fcstat.py is added


```
PLAY [Run fcstat command with various options on AIX] ****************************************************************************************************************************************************************

TASK [Run fcstat with default stats on fcs0] *************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxx]

TASK [Run fcstat with reset stats] ***********************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxx]

TASK [Run fcstat in remove delay] ************************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxx]

TASK [Run fcstat with all_statistics option] *************************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxx]

TASK [Run fcstat with all_statistics and remove_delay] ***************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxx]

TASK [Run fcstat time-series with 5 second interval] *****************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxx]

TASK [Run fcstat time-series for SCSI protocol] **********************************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxx]

TASK [Run fcstat time-series with interval 1 (single report)] ********************************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxx]

PLAY RECAP ***********************************************************************************************************************************************************************************************************
root@xxxxxxxxxxxxxx : ok=8    changed=8    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   



```