### PR TITLE
Added support for -K and -M in filesystem module

### DIFF
--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -374,6 +374,8 @@ def nfs_opts(module):
     perms = module.params["permissions"]
     mgroup = module.params["mount_group"]
     nfs_soft_mount = module.params["nfs_soft_mount"]
+    nfs_version = module.params['nfs_version']
+    sec_methods = module.params['nfs_sec_methods']
 
     opts = ""
     if amount == "yes":
@@ -389,6 +391,13 @@ def nfs_opts(module):
 
     if mgroup:
         opts += f"-m {mgroup} "
+    
+    if nfs_version:
+        opts += f"-K {nfs_version} "
+
+    if sec_methods:
+        methods = ','.join(sec_methods)
+        opts += f"-M {methods} "
 
     return opts
 
@@ -592,6 +601,8 @@ def main():
             mount_group=dict(type='str'),
             nfs_server=dict(type='str'),
             nfs_soft_mount=dict(type='bool', default='False'),
+            nfs_version=dict(type='str', choices=['any', '2', '3', '4']),
+            nfs_sec_methods=dict(type='list', elements='str'),
             state=dict(type='str', default='present', choices=['absent', 'present']),
             rm_mount_point=dict(type='bool', default='false'),
             filesystem=dict(type='str', required=True),

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -102,6 +102,16 @@ options:
     description:
     - Specifies a Network File System (NFS) server for NFS filesystem.
     type: str
+  nfs_version:
+    description:
+    - Specifies the NFS version to be used during NFS mount.
+    type: str
+    choices: [ any, 2, 3, 4 ]
+  nfs_sec_methods:
+    description:
+    - List of security methods to be used when attempting mount.
+    type: list
+    elements: str
 notes:
   - You can refer to the IBM documentation for additional information on the commands used at
     U(https://www.ibm.com/support/knowledgecenter/ssw_aix_72/c_commands/chfsmnt.html),
@@ -391,7 +401,7 @@ def nfs_opts(module):
 
     if mgroup:
         opts += f"-m {mgroup} "
-    
+
     if nfs_version:
         opts += f"-K {nfs_version} "
 

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -106,7 +106,7 @@ options:
     description:
     - Specifies the NFS version to be used during NFS mount.
     type: str
-    choices: [ any, 2, 3, 4 ]
+    choices: [ 'any', '2', '3', '4' ]
   nfs_sec_methods:
     description:
     - List of security methods to be used when attempting mount.


### PR DESCRIPTION
Fixes issue #277 


Test run details - 

Playbook used:
```
    - name: Create a NFS filesystem
      ibm.power_aix.filesystem:
        filesystem: /localnfspt
        state: present
        nfs_server: <nfs_server>
        device: /testnfs

    - name: Modify the NFS filesystem
      ibm.power_aix.filesystem:
        filesystem: /localnfspt
        state: present
        nfs_server: <nfs_server>
        device: /testnfs
        nfs_version: 3
        nfs_sec_methods: sys
    
    - name: Get information about the created fs
      raw: mount | grep localnfspt
      register: fs_info
      changed_when: false
    
    - name: Display the information about nfs
      ansible.builtin.debug:
        var: fs_info.stdout_lines
```

Output - 
```
PLAY [FILESYSTEM on AIX] **********************************************************************************************************************************

TASK [Create a NFS filesystem] ****************************************************************************************************************************
changed: [root@ XXXXXXXX]

TASK [Modify the NFS filesystem] **************************************************************************************************************************
changed: [root@ XXXXXXXX]

TASK [Get information about the created fs] ***************************************************************************************************************
ok: [root@ XXXXXXXX]

TASK [Display the information about nfs] ******************************************************************************************************************
ok: [root@ XXXXXXXX] => {
    "fs_info.stdout_lines": [
        "<nfs_server> /testnfs         /localnfspt      nfs3   Jan 13 23:43 rw,bg,hard,intr,vers=3,sec=sys"
    ]
}

PLAY RECAP ************************************************************************************************************************************************
root@XXXXXXXX : ok=4    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```