### PR TITLE
support phases in alt_disk modules

### DIFF
--- a/playbooks/demo_alt_disk.yml
+++ b/playbooks/demo_alt_disk.yml
@@ -28,6 +28,7 @@
     - name: Perform a cleanup of any existing alternate disk copy
       ibm.power_aix.alt_disk:
         action: clean
+        targets: hdisk3
 
     - name: Perform a cleanup of any existing alternate disk copy and old rootvg
       ibm.power_aix.alt_disk:
@@ -38,7 +39,46 @@
       ibm.power_aix.alt_disk:
         action: wakeup
         targets: hdisk3
+  
     - name: Perform an alternate disk sleep of the rootvg
       ibm.power_aix.alt_disk:
         action: sleep
         rebuild_boot_image: true
+
+    - name: Perform an alternate disk copy with phases and disk_size_policy
+      ibm.power_aix.alt_disk:
+        action: copy
+        phases_to_execute: 'all'
+        disk_size_policy: nearest
+        bootlist: true
+        force: true
+
+    - name: Perform an alternate disk copy of the rootvg with phases to hdisk2
+      ibm.power_aix.alt_disk:
+        action: copy
+        targets: hdisk2
+        phases_to_execute: '1'
+        bootlist: true
+        force: true
+
+    - name: Perform an alternate disk copy of the rootvg with phases to hdisk2
+      ibm.power_aix.alt_disk:
+        action: copy
+        targets: hdisk2
+        phases_to_execute: '2'
+        bootlist: true
+
+    - name: Perform an alternate disk copy of the rootvg with phases to hdisk2
+      ibm.power_aix.alt_disk:
+        action: copy
+        targets: hdisk2
+        phases_to_execute: '12'
+        bootlist: true
+        force: true
+
+    - name: Perform an alternate disk copy of the rootvg with phases to hdisk2
+      ibm.power_aix.alt_disk:
+        action: copy
+        targets: hdisk2
+        phases_to_execute: '3'
+        bootlist: true

--- a/plugins/modules/alt_disk.py
+++ b/plugins/modules/alt_disk.py
@@ -129,6 +129,16 @@ options:
     - Rebuilds the alternate boot image before putting the volume group to sleep.
     type: bool
     default: false
+  phases_to_execute:
+    description:
+    - When I(action=copy), specifies the phase or phases to execute during this invocation of alt_disk_copy.
+    - C(1) only phases 1 to execute
+    - C(2) only phases 2 to execute
+    - C(3) only phases 3 to execute
+    - C(12) phases 1 and phases 2 to execute
+    - C(23) phases 2 and phases 3 to execute
+    - C(all) all phases to execute (default)
+    type: str
 
 notes:
   - M(ibm.power_aix.alt_disk) only backs up mounted file systems. Mount all file
@@ -192,6 +202,21 @@ import re
 
 results = None
 mirrors = -1
+
+
+def get_last_phase_number():
+    filepath = "/var/adm/ras/alt_disk_inst.log"
+    try:
+        with open(filepath, 'r') as file:
+            lines = file.readlines()
+
+        for line in reversed(lines):
+            match = re.search(r'Phase\s+(\d+)', line)
+            if match:
+                return int(match.group(1))
+        return 0  # No phase number found
+    except FileNotFoundError:
+        return 0
 
 
 def get_pvs(module):
@@ -297,6 +322,7 @@ def find_valid_altdisk(module, hdisks, rootvg_info, disk_size_policy, force, all
     # check an alternate disk does not already exist
     found_altdisk = ''
     found_oldrootvg = ''
+    phase = module.params['phases_to_execute']
     for pv in pvs:
         if pvs[pv]['vg'] == 'altinst_rootvg':
             found_altdisk = pv
@@ -305,6 +331,35 @@ def find_valid_altdisk(module, hdisks, rootvg_info, disk_size_policy, force, all
         if allow_old_rootvg and pvs[pv]['vg'] == 'old_rootvg':
             found_oldrootvg = pv
             break
+    # phases to execute during this invocation
+
+    if found_altdisk and phase and not module.params['force']:
+        old_phase = get_last_phase_number()  # 1 / 2 / 3
+        if phase == "all":
+            if old_phase == 3:
+                results['msg'] = f"All phases already completed for disk {hdisks}. Nothing to do."
+                results['changed'] = False
+                module.exit_json(**results)
+            else:
+                return
+        if (old_phase == 1 and phase in ("2", "23")) or (old_phase == 2 and phase == "3"):
+            return
+
+        # block if ANY requested phase already completed
+        elif any(int(p) <= old_phase for p in phase if p.isdigit()):
+            results['msg'] = f"Phase {phase} is not allowed because phase {old_phase} is already completed for disk {hdisks}."
+            results['changed'] = False
+            module.exit_json(**results)
+        elif old_phase == 1 and phase == "3":
+            results['msg'] = f"After phase 1, only phase 2 or 23 is allowed. You are trying phase {phase}."
+            module.fail_json(**results)
+    elif found_altdisk and (phase not in ('1', '12', 'all')) and module.params['force']:
+        results['msg'] = 'The force option can only be used when phases_to_execute is set to one of the following: 1, 12 or all'
+        module.fail_json(**results)
+    elif not found_altdisk and phase in ("2", "23", "3"):
+        results['msg'] = f"Phase 1 has not been executed. Cannot run phase {phase} directly."
+        module.fail_json(**results)
+
     if found_altdisk or found_oldrootvg:
         if not force:
             if found_altdisk:
@@ -590,6 +645,8 @@ def alt_disk_copy(module, params, hdisks, allow_old_rootvg):
         cmd += ['-x', params['first_boot_script']]
     if params['resolvconf']:
         cmd += ['-R', params['resolvconf']]
+    if params['phases_to_execute']:
+        cmd += ['-P', params['phases_to_execute']]
 
     ret, stdout, stderr = module.run_command(cmd)
     results['rc'] = ret
@@ -851,6 +908,7 @@ def main():
             resolvconf=dict(type='str'),
             allow_old_rootvg=dict(type='bool', default=False),
             rebuild_boot_image=dict(type='bool', default=False),
+            phases_to_execute=dict(type='str', choices=['1', '2', '3', '12', '23', 'all']),
         ),
         mutually_exclusive=[
             ['targets', 'disk_size_policy']

--- a/plugins/modules/alt_disk.py
+++ b/plugins/modules/alt_disk.py
@@ -139,7 +139,7 @@ options:
     - C(23) phases 2 and phases 3 to execute
     - C(all) all phases to execute (default)
     type: str
-    choices: [ 1, 2, 3, 12, 23, all ]
+    choices: [ '1', '2', '3', '12', '23', 'all' ]
 
 notes:
   - M(ibm.power_aix.alt_disk) only backs up mounted file systems. Mount all file

--- a/plugins/modules/alt_disk.py
+++ b/plugins/modules/alt_disk.py
@@ -139,6 +139,7 @@ options:
     - C(23) phases 2 and phases 3 to execute
     - C(all) all phases to execute (default)
     type: str
+    choices: [ 1, 2, 3, 12, 23, all ]
 
 notes:
   - M(ibm.power_aix.alt_disk) only backs up mounted file systems. Mount all file

--- a/tests/unit/plugins/modules/test_alt_disk.py
+++ b/tests/unit/plugins/modules/test_alt_disk.py
@@ -17,7 +17,7 @@ def reset_results_and_module():
 
     # make a mock module object used by functions
     module = mock.Mock()
-    module.params = {}
+    module.params = {'phases_to_execute': None}
     module.log = mock.Mock()
     module.debug = mock.Mock()
     module.fail_json = mock.Mock(side_effect=RuntimeError("fail_json called"))


### PR DESCRIPTION
Fixes enhancemnet  #646 

Demo run :
```
PLAY [ALT_DISK on AIX] **********************************************************************************************************************************************************************************************

TASK [Perform an alternate disk copy with phases and disk_size_policy] **********************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxx]

TASK [Perform an alternate disk copy of the rootvg with phases to hdisk2] *******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxx]

TASK [Perform an alternate disk copy of the rootvg with phases to hdisk2] *******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxx]

TASK [Perform an alternate disk copy of the rootvg with phases to hdisk2] *******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxx]

TASK [Perform an alternate disk copy of the rootvg with phases to hdisk2] *******************************************************************************************************************************************
changed: [root@xxxxxxxxxxxxxxxxxxx]

PLAY RECAP **********************************************************************************************************************************************************************************************************
root@xxxxxxxxxxxxxxxxxxx         : ok=5    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

``` 

