### PR TITLE
Changed eda source plugin location and code as per community guideline

### DIFF
--- a/extensions/eda/plugins/event_source/aix_cpu_watch.py
+++ b/extensions/eda/plugins/event_source/aix_cpu_watch.py
@@ -202,7 +202,6 @@ source:
   returned: always
 '''
 
-from ansible_rulebook.source import Source
 import asyncio
 from datetime import datetime, timezone
 import paramiko
@@ -280,16 +279,15 @@ class _SSHClient:
             self._client = None
 
 
-@Source(name="aix_cpu_watch")
-class AIXCPUWatch:
+async def main(queue: asyncio.Queue, args: Dict[str, Any]):
     """
     EDA event source: aix_cpu_watch
+    Main entry point for the event source plugin.
     """
-    def __init__(self):
-        self.clients: Dict[str, _SSHClient] = {}
-        self.running = True
-
-    async def run(self, queue, args):
+    clients: Dict[str, _SSHClient] = {}
+    running = True
+    
+    try:
         hosts: List[Dict[str, Any]] = args.get("hosts", [])
         if not hosts:
             raise ValueError("AIXCPUWatch: 'hosts' list is required.")
@@ -302,7 +300,7 @@ class AIXCPUWatch:
         # Prepare SSH clients
         for h in hosts:
             key = h["host"]
-            self.clients[key] = _SSHClient(
+            clients[key] = _SSHClient(
                 host=h["host"],
                 username=h.get("username", "root"),
                 port=int(h.get("port", 22)),
@@ -311,56 +309,55 @@ class AIXCPUWatch:
                 timeout=int(h.get("timeout", 10)),
             )
 
-        try:
-            while self.running:
-                start = asyncio.get_event_loop().time()
+        while running:
+            start = asyncio.get_event_loop().time()
 
-                async def poll_one(h: Dict[str, Any]):
-                    host = h["host"]
-                    cli = self.clients[host]
-                    try:
-                        # Run vmstat once per cycle
-                        out = await asyncio.to_thread(cli.run, sample_cmd)
-                        # Use the last non-empty line (tail -1 already, but be safe)
-                        lines = [line for line in out.splitlines() if line.strip()][-1]
-                        if not lines:
-                            raise ValueError("vmstat returned no data")
-                        cpu = _compute_cpu_usage_from_vmstat(lines)
-                        crossed = cpu["usage"] >= threshold
-                        if (not emit_only_above) or crossed:
-                            event = {
-                                "timestamp": datetime.now(timezone.utc).isoformat(),
-                                "host": host,
-                                "cpu": {
-                                    "percent": round(cpu["usage"], 2),
-                                    "us": cpu["us"],
-                                    "sy": cpu["sy"],
-                                    "id": cpu["id"],
-                                    "wa": cpu["wa"],
-                                },
-                                "threshold": threshold,
-                                "crossed": crossed,
-                                "source": "aix_cpu_watch",
-                            }
-                            await queue.put(event)
-                    except Exception as e:
-                        err_event = {
+            async def poll_one(h: Dict[str, Any]):
+                host = h["host"]
+                cli = clients[host]
+                try:
+                    # Run vmstat once per cycle
+                    out = await asyncio.to_thread(cli.run, sample_cmd)
+                    # Use the last non-empty line (tail -1 already, but be safe)
+                    lines = [line for line in out.splitlines() if line.strip()][-1]
+                    if not lines:
+                        raise ValueError("vmstat returned no data")
+                    cpu = _compute_cpu_usage_from_vmstat(lines)
+                    crossed = cpu["usage"] >= threshold
+                    if (not emit_only_above) or crossed:
+                        event = {
                             "timestamp": datetime.now(timezone.utc).isoformat(),
                             "host": host,
-                            "error": str(e),
+                            "cpu": {
+                                "percent": round(cpu["usage"], 2),
+                                "us": cpu["us"],
+                                "sy": cpu["sy"],
+                                "id": cpu["id"],
+                                "wa": cpu["wa"],
+                            },
+                            "threshold": threshold,
+                            "crossed": crossed,
                             "source": "aix_cpu_watch",
-                            "severity": "error",
                         }
-                        # Always emit errors so rules can alert
-                        await queue.put(err_event)
+                        await queue.put(event)
+                except Exception as e:
+                    err_event = {
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "host": host,
+                        "error": str(e),
+                        "source": "aix_cpu_watch",
+                        "severity": "error",
+                    }
+                    # Always emit errors so rules can alert
+                    await queue.put(err_event)
 
-                # Poll all hosts concurrently
-                await asyncio.gather(*(poll_one(h) for h in hosts))
+            # Poll all hosts concurrently
+            await asyncio.gather(*(poll_one(h) for h in hosts))
 
-                # Sleep until next tick (interval from loop start)
-                elapsed = asyncio.get_event_loop().time() - start
-                await asyncio.sleep(max(0, interval - elapsed))
-        finally:
-            # Cleanup SSH sessions
-            for cli in self.clients.values():
-                cli.close()
+            # Sleep until next tick (interval from loop start)
+            elapsed = asyncio.get_event_loop().time() - start
+            await asyncio.sleep(max(0, interval - elapsed))
+    finally:
+        # Cleanup SSH sessions
+        for cli in clients.values():
+            cli.close()


### PR DESCRIPTION
- Changed directory structure of Eda source_plugins 
- Changed template of existing source plugin `aix_cpu_watch.py`

These changes were required as per the latest community guidelines. 

Guidelines available at - 

For directory structure - https://docs.ansible.com/projects/rulebook/en/v1.2.0/collections.html
Code template - https://docs.ansible.com/projects/rulebook/en/v1.2.0/sources.html

**Machine output:**
```
** 2026-05-22 15:30:54.070679 [event] *********************************************************************************************************************
{'cpu': {'id': 99.0, 'percent': 0.0, 'sy': 0.0, 'us': 0.0, 'wa': 0.0},
 'crossed': False,
 'host': 'X.X.X.X',
 'meta': {'received_at': '2026-05-22T10:00:54.061963Z',
          'rule_engine': {'once_within_time_window': '1 MINUTES'},
          'source': {'name': 'ibm.power_aix.aix_cpu_watch',
                     'type': 'ibm.power_aix.aix_cpu_watch'},
          'uuid': 'd6d876b0-ab28-4238-846e-33057991fda6'},
 'source': 'aix_cpu_watch',
 'threshold': 25.0,
 'timestamp': '2026-05-22T10:00:54.061926+00:00'}
***********************************************************************************************************************************************************
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
[WARNING]: Skipping '   ansible_connection' as this is not a valid group definition
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Notify High CPU Usage] ***************************************************

TASK [Display high CPU alert] **************************************************
ok: [localhost] => {
    "msg": "========================================\nHIGH CPU ALERT\n========================================\nHost: X.X.X.X\nCPU Usage: 0.0%\nThreshold: 25.0%\nTimestamp: 2026-05-22T10:00:54.061926+00:00\n\nCPU Breakdown:\n- User (us): 0.0%\n- System (sy): 0.0%\n- IO Wait (wa): 0.0%\n- Idle (id): 99.0%\n========================================\n"
}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
[WARNING]: Skipping '   ansible_connection' as this is not a valid group definition
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Send Email Notification] *************************************************

TASK [Display email notification placeholder] **********************************
ok: [localhost] => {
    "msg": "========================================\nEMAIL NOTIFICATION (Placeholder)\n========================================\nThis is where you would configure email notifications.\n\nEvent Details:\nHost: X.X.X.X\nCPU Usage: 0.0%\nThreshold: 25.0%\nTimestamp: 2026-05-22T10:00:54.061926+00:00\n\nTo enable email notifications, configure the mail module\nwith your SMTP settings.\n========================================\n"
}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
[WARNING]: Skipping '   ansible_connection' as this is not a valid group definition
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Act on AIX Host with High CPU] *******************************************

TASK [Display action placeholder] **********************************************
ok: [localhost] => {
    "msg": "========================================\nTAKING ACTION ON AIX HOST\n========================================\nHost: X.X.X.X\nCPU Usage: 0.0%\n\nThis is where you would implement remediation actions such as:\n- Identifying top CPU consuming processes\n- Restarting specific services\n- Scaling resources\n- Triggering alerts to on-call teams\n========================================\n"
}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```