### PR TITLE
Added mutual exclusiveness and size not provided check in filesystem

### DIFF
--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -120,6 +120,10 @@ notes:
     U(https://www.ibm.com/support/knowledgecenter/ssw_aix_72/m_commands/mknfsmnt.html),
     U(https://www.ibm.com/support/knowledgecenter/ssw_aix_72/r_commands/rmfs.html),
     U(https://www.ibm.com/support/knowledgecenter/ssw_aix_72/r_commands/rmnfsmnt.html).
+  - 'Parameter requirements based on I(action):'
+  - If I(action=present) and a filesystem needs to be created, then C(size) is required.
+  - If I(action=present) and a local filesystem needs to be created, you need to use
+    either C(vg) or C(device), both can not used together.
 '''
 
 EXAMPLES = r'''
@@ -523,11 +527,18 @@ def mkfs(module, filesystem):
     else:
         # Create a local filesystem
         opts = fs_opts(module)
+        if '-a size=' not in opts:
+            result['msg'] = "You need to provide size when trying to create a filesystem."
+            module.fail_json(**result)
 
         fs_type = module.params['fs_type']
 
         vg = module.params['vg']
         if vg:
+            if device:
+                result['msg'] = "You can only use one of the following while creating a filesystem:"
+                result['msg'] += " vg, device"
+                module.fail_json(**result)
             vg = f"-g {vg} "
         else:
             vg = ""


### PR DESCRIPTION
Fixes #750

**Sample code run (failure):**

When vg and device both are provided
```
fatal: [root@X.X.X.X]: FAILED! => {
    "changed": false,
    "cmd": "",
    "invocation": {
        "module_args": {
            "account_subsystem": null,
            "attributes": [
                "size=32768",
                "isnapshot='no'"
            ],
            "auto_mount": null,
            "device": "fslv00",
            "filesystem": "/testfs",
            "fs_type": "jfs2",
            "mount_group": null,
            "nfs_sec_methods": null,
            "nfs_server": null,
            "nfs_soft_mount": false,
            "nfs_version": null,
            "permissions": "rw",
            "rm_mount_point": false,
            "state": "present",
            "vg": "appvg"
        }
    },
    "msg": "You can only use one of the following while creating a filesystem: vg, device",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "",
    "stdout_lines": []
```

When size is not provided - 
```
fatal: [root@X.X.X.X]: FAILED! => {
    "changed": false,
    "cmd": "",
    "invocation": {
        "module_args": {
            "account_subsystem": null,
            "attributes": [
                "isnapshot='no'"
            ],
            "auto_mount": null,
            "device": null,
            "filesystem": "/testfs",
            "fs_type": "jfs2",
            "mount_group": null,
            "nfs_sec_methods": null,
            "nfs_server": null,
            "nfs_soft_mount": false,
            "nfs_version": null,
            "permissions": "rw",
            "rm_mount_point": false,
            "state": "present",
            "vg": "appvg"
        }
    },
    "msg": "You need to provide size when trying to create a filesystem.",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "",
    "stdout_lines": []
```


**Sample code run (success):**
```
changed: [root@X.X.X.X] => {
    "changed": true,
    "cmd": "crfs -v jfs2 -g appvg -m /testfs -a size=32768 -a isnapshot='no' -p rw ",
    "invocation": {
        "module_args": {
            "account_subsystem": null,
            "attributes": [
                "size=32768",
                "isnapshot='no'"
            ],
            "auto_mount": null,
            "device": null,
            "filesystem": "/testfs",
            "fs_type": "jfs2",
            "mount_group": null,
            "nfs_sec_methods": null,
            "nfs_server": null,
            "nfs_soft_mount": false,
            "nfs_version": null,
            "permissions": "rw",
            "rm_mount_point": false,
            "state": "present",
            "vg": "appvg"
        }
    },
    "msg": "Creation of filesystem /testfs succeeded",
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "",
    "stdout_lines": []
}

```