### PR TITLE
Removed stale shebang

### DIFF
--- a/tests/sanity/sanity.requirements
+++ b/tests/sanity/sanity.requirements
@@ -11,4 +11,3 @@ shellcheck-py
 changelog
 ignores
 pep8
-shebang


### PR DESCRIPTION
Shebang is not available for python versions >= 3.7 so have to remove it. 

From previous PR runs
```
ERROR: Ignored the following versions that require a different python version:
       1.9.5 Requires-Python !=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7,<3.7
ERROR: Could not find a version that satisfies the requirement shebang (from versions: none)
```